### PR TITLE
deploy: k8s manifests + transcription plan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,24 @@
-FROM rust:latest
+# syntax=docker/dockerfile:1.6
 
-WORKDIR rankore
-COPY ./Cargo.toml .
+FROM rust:1.83-slim-bookworm AS builder
+WORKDIR /app
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY Cargo.toml Cargo.lock ./
+COPY .sqlx ./.sqlx
+COPY src ./src
+COPY migrations ./migrations
+COPY assets ./assets
+ENV SQLX_OFFLINE=true
+RUN cargo build --release --bin rankore
 
-RUN apt update && apt install -y clang
-COPY ./src ./src
-COPY .sqlx/ ./.sqlx/
-RUN mkdir ./tmp
-COPY ./assets ./assets
-COPY README.md ./README.md
-RUN SQLX_OFFLINE=true cargo build --release
-
-CMD ["target/release/rankore"]
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/target/release/rankore /app/rankore
+COPY --from=builder /app/assets /app/assets
+ENV RUST_BACKTRACE=1
+CMD ["/app/rankore"]

--- a/docs/transcription-plan.md
+++ b/docs/transcription-plan.md
@@ -1,0 +1,204 @@
+# Voice-to-text transcription — design and plan
+
+Goal: while the bot is in a Discord voice channel, capture each user's audio,
+transcribe it, and append the result to a per-session text file the server can
+download via a chat command.
+
+This is a non-trivial feature: Discord's voice receive API is undocumented and
+unstable, the audio pipeline is real-time, and there are consent/legal
+considerations distinct from the rest of the bot. Below is the design and a
+phased plan, not an implementation.
+
+---
+
+## 1. Constraints and scope
+
+- **Discord voice ingest is unofficial.** Discord supports voice send through
+  documented APIs but voice *receive* is not officially supported. The standard
+  workaround is the [Songbird](https://github.com/serenity-rs/songbird) crate,
+  which speaks the same gateway as Discord clients and decodes the per-speaker
+  Opus streams. Songbird supports voice receive but the underlying packet
+  format has changed before and may again.
+- **The bot has to *join* the channel.** It cannot eavesdrop on a channel it
+  isn't in. Joining is a visible action; users will see "Rankore joined voice."
+- **Consent.** The bot must announce that recording is active when it joins
+  and ideally support per-user opt-out before any transcript is persisted.
+  Some jurisdictions (and Discord's own terms) require all-party consent for
+  voice recording.
+- **Songbird ↔ serenity version coupling.** Songbird `0.3.x` pairs with
+  serenity `0.11.x` (what we're on); newer songbird requires newer serenity.
+  Upgrading serenity is its own task and bundles unrelated API churn.
+
+## 2. Architecture
+
+```
+        ┌──────────────────────────────────────────────────────────┐
+        │ Discord voice gateway (UDP)                              │
+        │   per-speaker Opus packets, 48kHz/20ms frames            │
+        └─────────────────────┬────────────────────────────────────┘
+                              │
+                  ┌───────────▼──────────┐
+                  │ Songbird driver      │  bot process (Rust)
+                  │ — VoiceReceiveEvent  │
+                  └───────────┬──────────┘
+                              │ per-(guild, channel, user) Opus stream
+                              │
+                  ┌───────────▼──────────┐
+                  │ Decoder + resampler  │  opus -> PCM s16 48k stereo
+                  │ (opus, rubato)       │  -> PCM s16 16k mono
+                  └───────────┬──────────┘
+                              │ 16k mono PCM
+                              │
+                  ┌───────────▼──────────┐
+                  │ Voice-activity       │  silero-vad-rs or webrtc-vad
+                  │ detector / segmenter │  -> utterance buffers (~0.5–10s)
+                  └───────────┬──────────┘
+                              │ utterance WAV
+                              │  (HTTP POST)
+                  ┌───────────▼──────────┐
+                  │ whisper service      │  separate k8s Deployment,
+                  │ (whisper.cpp HTTP)   │  CPU or GPU node, model on PVC
+                  └───────────┬──────────┘
+                              │ text + start/end timestamps
+                              │
+                  ┌───────────▼──────────┐
+                  │ Transcript writer    │  appends to per-session file on PVC
+                  └──────────────────────┘
+```
+
+### Why a separate STT service
+
+Keeping Whisper out of the bot process has three benefits:
+1. **Decoupled scaling.** STT is compute-heavy; the bot is event-driven. Sizing
+   them together is wasteful.
+2. **Restart safety.** A whisper.cpp crash doesn't take the bot down.
+3. **Model swap.** Tiny/base/medium/large are a config change, not a redeploy.
+
+The bot talks HTTP to it (e.g., `POST /transcribe` with `audio/wav` body).
+
+## 3. Engine choice
+
+| Option | Cost | Latency | Privacy | Notes |
+|---|---|---|---|---|
+| **whisper.cpp** self-hosted | none | ~real-time on `small` CPU, faster on GPU/Metal | data stays on the cluster | recommended for the homelab |
+| OpenAI Whisper API | $0.006/min | low | audio leaves the cluster | trivial integration |
+| Deepgram / AssemblyAI streaming | paid | <1s end-to-end | external | best UX but external |
+| faster-whisper (CTranslate2) | none | faster than whisper.cpp on CPU | local | needs Python sidecar |
+
+**Recommendation:** start with whisper.cpp `base` or `small` model on CPU. Move
+to GPU or faster-whisper if latency is a problem.
+
+## 4. Audio plumbing details
+
+- Discord sends each speaker as a separate SSRC. Songbird's
+  `EventContext::VoiceTick` (newer) or `EventContext::SpeakingUpdate` /
+  `VoicePacket` (older) maps SSRC ↔ user_id, with a small race window at the
+  start of a user speaking.
+- Each user gets a ring buffer (e.g. 60s capacity). VAD slices speech segments.
+- Speech segments shorter than ~300ms get dropped; longer than ~10s get
+  force-flushed to keep latency bounded.
+- Resampling: 48k stereo → 16k mono via `rubato` (sinc) or `dasp`. Channel
+  downmix is `(L+R)/2`.
+
+## 5. Discord-side commands and UX
+
+- `!transcribe_join` — bot joins the caller's current voice channel and starts
+  capturing. Replies with a consent banner naming the active session.
+- `!transcribe_leave` — bot leaves and finalizes the transcript. Replies with
+  a summary and the transcript file (using the existing `send_titled_files`
+  path).
+- `!transcribe_status` — current session info (channel, duration, opted-out
+  users).
+- `!transcribe_optout` / `!transcribe_optin` — per-user toggle. Opt-out users'
+  audio is dropped at the SSRC mapping step before it reaches any disk.
+
+Sessions are keyed by `(guild_id, channel_id, started_at)`.
+
+## 6. Storage
+
+- Transcripts: append-only `.txt` per session, on a PVC mounted into the bot.
+  Format: `[HH:MM:SS] @nick: utterance text`.
+- Retention: configurable, default 30 days; cleanup CronJob in the namespace.
+- Raw audio: **not retained** unless an explicit debug flag is set. Discarded
+  after the utterance is transcribed.
+
+## 7. Kubernetes shape
+
+Two new workloads in the `rankore` namespace:
+
+- `whisper` Deployment + Service
+  - image: `ghcr.io/ggerganov/whisper.cpp:server` (or a self-built image with
+    a particular model baked in)
+  - PVC for the model file (avoids re-downloading on restart)
+  - resources: 2 vCPU / 4Gi for `small`, 4 vCPU / 8Gi for `medium`
+- The existing `rankore` Deployment gets a transcripts PVC mount and a
+  `WHISPER_URL=http://whisper:9000` env var.
+
+Optional: a `transcript-pruner` CronJob that removes files older than the
+retention window.
+
+## 8. Dependencies (Rust side)
+
+```toml
+songbird = { version = "0.3", default-features = false, features = [
+    "serenity", "rustls", "driver", "gateway",
+] }
+audiopus = "0.3"          # Opus decode
+rubato = "0.14"           # resampling
+hound = "3.5"             # WAV write for HTTP body
+silero-vad = "0.x"        # or webrtc-vad = "0.4"
+reqwest = { version = "0.11", features = ["multipart", "stream"] }
+```
+
+`audiopus` builds against `libopus`; the runtime image needs it (`apt-get
+install libopus0`).
+
+## 9. Phased rollout
+
+Each phase is independently shippable.
+
+1. **Songbird wiring + raw audio dump.** Add commands `!transcribe_join` /
+   `!transcribe_leave`. Bot joins voice and writes per-user raw PCM to a tmp
+   file. No STT yet. Validates that voice receive works on this serenity
+   version, that SSRC ↔ user mapping is reliable, and that the consent UX
+   feels right.
+2. **whisper.cpp service in-cluster.** Stand up the whisper Deployment +
+   Service + model PVC. Smoke test with `curl` from a debug pod.
+3. **STT integration.** Bot resamples + segments PCM, posts utterances to the
+   whisper service, appends transcript lines to a session file. Single user
+   first, then multi-speaker.
+4. **VAD-driven segmenter.** Replace the naive fixed-window segmenter with VAD
+   to cut silence and improve word boundaries.
+5. **Opt-out + consent UX polish.** Per-user opt-out, in-channel banner on
+   join, transcript header naming participants who consented.
+6. **Retention CronJob.** Configurable TTL.
+
+Estimated effort: phases 1–3 are the bulk (~2–3 weeks of focused work);
+phases 4–6 are smaller polish (~1 week combined).
+
+## 10. Risks
+
+- **Songbird voice-receive API drift.** Mitigation: pin the songbird version,
+  keep the receive code in one module behind a small trait so swapping it is
+  isolated.
+- **Latency under load.** Multiple concurrent speakers × CPU whisper may
+  fall behind real time. Mitigation: per-user back-pressure (drop segments
+  rather than queue unboundedly); the segmenter already bounds buffer length.
+- **Discord ToS / privacy law.** Mitigation: explicit consent banner,
+  per-user opt-out, no raw audio retention by default, clear documentation
+  of retention.
+- **Memory.** whisper-small: ~500MB resident; whisper-medium: ~1.5GB. Sized
+  in the k8s resources.
+- **serenity 0.11 EOL.** Newer songbird requires serenity 0.12+. If we have
+  to upgrade serenity, the bulk of the bot code stays the same but the
+  builder APIs and some event signatures change. Worth scoping that upgrade
+  separately before phase 1 if we hit blockers.
+
+## 11. Out of scope (for now)
+
+- Real-time captions posted into a text channel during the call.
+- Speaker diarization beyond what Discord gives us (Discord already gives us
+  per-speaker streams, so this is mostly free).
+- Translation.
+- Multi-language detection per utterance (rely on whisper's `--language`
+  per session, set when joining).

--- a/docs/transcription-plan.md
+++ b/docs/transcription-plan.md
@@ -76,39 +76,66 @@ Keeping Whisper out of the bot process has three benefits:
 
 The bot talks HTTP to it (e.g., `POST /transcribe` with `audio/wav` body).
 
-## 3. Engine choice — sized for low-cost hardware
+## 3. Engine choice — multilingual, low-cost hardware
 
-Target: a single k3s node with 2–4 CPU cores and a few GB of free RAM, no GPU.
-This rules out anything from `medium` upward; even `small` is borderline once
-the bot, Postgres, and other workloads are on the same node.
+Required languages: English, Italian, Spanish, French. That rules out the
+`.en` whisper variants (English-only) and rules out Vosk (one model per
+language; would require loading four). The remaining choice is which size of
+the multilingual whisper model to run.
 
-### Model shortlist
+Target hardware: a single k3s node with 2–4 CPU cores and a few GB of free
+RAM, no GPU. This rules out anything from `medium` upward; even `small` is
+borderline once the bot, Postgres, and other workloads share the node.
 
-| Model | Params | RAM (Q5_0) | Disk (Q5_0) | RTF on 4×x86_64 CPU | Languages | Quality |
+### Model shortlist (multilingual only)
+
+| Model | Params | RAM (Q5_0) | Disk (Q5_0) | RTF on 4×x86_64 CPU | EN | IT/ES/FR quality |
 |---|---|---|---|---|---|---|
-| whisper.cpp `tiny.en`   | 39M  | ~75 MB  | ~30 MB  | ~0.10× | English only | usable for simple speech |
-| whisper.cpp `base.en`   | 74M  | ~140 MB | ~60 MB  | ~0.20× | English only | clearly better; recommended |
-| whisper.cpp `tiny`      | 39M  | ~75 MB  | ~30 MB  | ~0.10× | multilingual | mediocre |
-| whisper.cpp `base`      | 74M  | ~140 MB | ~60 MB  | ~0.20× | multilingual | acceptable |
-| whisper.cpp `small.en`  | 244M | ~500 MB | ~190 MB | ~0.50× | English only | great if you have headroom |
-| Vosk `small-en-us`      | —    | ~80 MB  | ~40 MB  | ~0.05× | English only | worse than whisper but very efficient |
+| whisper.cpp `tiny`   | 39M  | ~75 MB  | ~30 MB  | ~0.10× | mediocre | poor — frequent errors |
+| whisper.cpp `base`   | 74M  | ~140 MB | ~60 MB  | ~0.20× | acceptable | acceptable for clear speech; degrades with accent / background noise |
+| whisper.cpp `small`  | 244M | ~500 MB | ~190 MB | ~0.50× | good | good — large jump over `base` for non-English |
 
-RTF = real-time factor; RTF < 1.0 means faster than real time, so a single
-4-core box can keep up with one speaker.
+RTF = real-time factor (lower is faster than real time). Numbers from the
+whisper.cpp benchmarks, ggml Q5_0 quantization.
+
+The accuracy gap between `base` and `small` is significantly wider for
+Italian / Spanish / French than for English, because the training data is
+English-dominant and smaller models overfit to it. If hardware allows, `small`
+is the right starting point for a multilingual server.
 
 ### Recommendation
 
-- **English-only servers:** `whisper.cpp base.en` with Q5_0 quantization.
-  ~140 MB RAM, ~60 MB on disk, comfortably real-time on 2 CPU cores. Quality
-  is solidly better than `tiny.en` for not much more cost.
-- **Multilingual servers:** `whisper.cpp base` Q5_0. Same footprint.
-- **Sub-Raspberry-Pi-class hardware:** `tiny.en` Q5_0. Still useful.
-- **Lots of CPU headroom and English-only:** jump to `small.en` Q5_0 for
-  noticeably better accuracy. Skip anything larger; `medium` needs ~2 GB RAM
-  and an RTF around 1.0 on 4 cores, i.e. exactly real-time with no margin.
+- **Default:** `whisper.cpp small` Q5_0 multilingual. ~500 MB RAM, ~190 MB on
+  disk, RTF ~0.5 on 4 CPU cores. Real-time with margin for one speaker;
+  with multiple concurrent speakers it relies on per-user back-pressure
+  (see §10 risks).
+- **If `small` is too heavy** for the node: fall back to `base` Q5_0.
+  Expect noticeably more errors on Italian / Spanish / French, especially
+  with accents or background noise. Acceptable as a starting point; revisit
+  once you've heard it transcribe real conversations.
+- **Hard ceiling:** `medium` (~2 GB RAM, RTF ≈ 1.0 on 4 cores) is out of
+  scope for the homelab hardware budget. If `small` isn't good enough,
+  switching to `faster-whisper` with `small` (CTranslate2 backend) is the
+  cheaper next step than upsizing the model.
 
 Quantized GGML models are at https://huggingface.co/ggerganov/whisper.cpp.
-Pull the `*-q5_0.bin` variant.
+Pull `ggml-small-q5_0.bin` (or `ggml-base-q5_0.bin` as the fallback).
+
+### Language handling
+
+whisper supports two modes:
+1. **Auto-detect per utterance** — slower (~5–10% overhead) but handles a
+   guild that switches languages mid-conversation.
+2. **Pinned per session** — set `language=it` (or `es`, `fr`, `en`) when the
+   session starts. Faster and slightly more accurate.
+
+Expose this in the join command:
+- `!transcribe_join` — auto-detect (default).
+- `!transcribe_join lang=it` — pin to Italian. Same for `es`, `fr`, `en`.
+
+Reject anything outside this whitelist of four to avoid surprises; whisper
+will happily *try* any of its 99 languages but quality on the long tail at
+`small` size is unreliable.
 
 ### Engines considered and rejected
 
@@ -165,12 +192,15 @@ Two new workloads in the `rankore` namespace:
 
 - `whisper` Deployment + Service
   - image: `ghcr.io/ggerganov/whisper.cpp:server` (or a self-built thin image)
-  - PVC for the model file (~60 MB for `base.en` Q5_0) so the model isn't
+  - PVC for the model file (~190 MB for `small` Q5_0) so the model isn't
     re-downloaded on restart
-  - resources sized for `base.en` Q5_0:
-    - requests: 500m CPU / 256Mi RAM
-    - limits:   2 CPU / 512Mi RAM
-  - If you later swap to `small.en`, bump the limits to 4 CPU / 1Gi RAM.
+  - resources sized for `small` Q5_0 multilingual:
+    - requests: 1 CPU / 512Mi RAM
+    - limits:   4 CPU / 1Gi RAM
+  - Env: `WHISPER_MODEL=small` (or `base` to fall back). Language is passed
+    per request, not as deployment config.
+  - If `small` doesn't fit on the node, fall back to `base` and tighten the
+    limits to 2 CPU / 512Mi RAM.
 - The existing `rankore` Deployment gets a transcripts PVC mount and a
   `WHISPER_URL=http://whisper:9000` env var.
 
@@ -227,9 +257,13 @@ phases 4–6 are smaller polish (~1 week combined).
 - **Discord ToS / privacy law.** Mitigation: explicit consent banner,
   per-user opt-out, no raw audio retention by default, clear documentation
   of retention.
-- **Memory.** Recommended `base.en` Q5_0: ~140 MB resident. `small.en` Q5_0:
-  ~500 MB. `medium` and up are intentionally out of scope for the homelab
-  hardware budget.
+- **Memory.** Recommended `small` Q5_0 multilingual: ~500 MB resident.
+  `base` Q5_0 fallback: ~140 MB. `medium` and up are intentionally out of
+  scope for the homelab hardware budget.
+- **Non-English accuracy.** Smaller whisper models are trained on a
+  largely-English corpus; quality on Italian / Spanish / French degrades
+  faster with size reduction than English does. Validate accuracy with
+  real recordings in each target language before committing to `base`.
 - **serenity 0.11 EOL.** Newer songbird requires serenity 0.12+. If we have
   to upgrade serenity, the bulk of the bot code stays the same but the
   builder APIs and some event signatures change. Worth scoping that upgrade
@@ -240,6 +274,9 @@ phases 4–6 are smaller polish (~1 week combined).
 - Real-time captions posted into a text channel during the call.
 - Speaker diarization beyond what Discord gives us (Discord already gives us
   per-speaker streams, so this is mostly free).
-- Translation.
-- Multi-language detection per utterance (rely on whisper's `--language`
-  per session, set when joining).
+- Translation (whisper can do English-target translation; we keep it
+  separate to avoid coupling source-language quality issues to a translation
+  step).
+- Languages outside the EN / IT / ES / FR whitelist. whisper will accept
+  others but at `small` size accuracy on the long tail is unreliable, and
+  we'd rather refuse than ship bad transcripts.

--- a/docs/transcription-plan.md
+++ b/docs/transcription-plan.md
@@ -76,17 +76,54 @@ Keeping Whisper out of the bot process has three benefits:
 
 The bot talks HTTP to it (e.g., `POST /transcribe` with `audio/wav` body).
 
-## 3. Engine choice
+## 3. Engine choice — sized for low-cost hardware
 
-| Option | Cost | Latency | Privacy | Notes |
-|---|---|---|---|---|
-| **whisper.cpp** self-hosted | none | ~real-time on `small` CPU, faster on GPU/Metal | data stays on the cluster | recommended for the homelab |
-| OpenAI Whisper API | $0.006/min | low | audio leaves the cluster | trivial integration |
-| Deepgram / AssemblyAI streaming | paid | <1s end-to-end | external | best UX but external |
-| faster-whisper (CTranslate2) | none | faster than whisper.cpp on CPU | local | needs Python sidecar |
+Target: a single k3s node with 2–4 CPU cores and a few GB of free RAM, no GPU.
+This rules out anything from `medium` upward; even `small` is borderline once
+the bot, Postgres, and other workloads are on the same node.
 
-**Recommendation:** start with whisper.cpp `base` or `small` model on CPU. Move
-to GPU or faster-whisper if latency is a problem.
+### Model shortlist
+
+| Model | Params | RAM (Q5_0) | Disk (Q5_0) | RTF on 4×x86_64 CPU | Languages | Quality |
+|---|---|---|---|---|---|---|
+| whisper.cpp `tiny.en`   | 39M  | ~75 MB  | ~30 MB  | ~0.10× | English only | usable for simple speech |
+| whisper.cpp `base.en`   | 74M  | ~140 MB | ~60 MB  | ~0.20× | English only | clearly better; recommended |
+| whisper.cpp `tiny`      | 39M  | ~75 MB  | ~30 MB  | ~0.10× | multilingual | mediocre |
+| whisper.cpp `base`      | 74M  | ~140 MB | ~60 MB  | ~0.20× | multilingual | acceptable |
+| whisper.cpp `small.en`  | 244M | ~500 MB | ~190 MB | ~0.50× | English only | great if you have headroom |
+| Vosk `small-en-us`      | —    | ~80 MB  | ~40 MB  | ~0.05× | English only | worse than whisper but very efficient |
+
+RTF = real-time factor; RTF < 1.0 means faster than real time, so a single
+4-core box can keep up with one speaker.
+
+### Recommendation
+
+- **English-only servers:** `whisper.cpp base.en` with Q5_0 quantization.
+  ~140 MB RAM, ~60 MB on disk, comfortably real-time on 2 CPU cores. Quality
+  is solidly better than `tiny.en` for not much more cost.
+- **Multilingual servers:** `whisper.cpp base` Q5_0. Same footprint.
+- **Sub-Raspberry-Pi-class hardware:** `tiny.en` Q5_0. Still useful.
+- **Lots of CPU headroom and English-only:** jump to `small.en` Q5_0 for
+  noticeably better accuracy. Skip anything larger; `medium` needs ~2 GB RAM
+  and an RTF around 1.0 on 4 cores, i.e. exactly real-time with no margin.
+
+Quantized GGML models are at https://huggingface.co/ggerganov/whisper.cpp.
+Pull the `*-q5_0.bin` variant.
+
+### Engines considered and rejected
+
+| Option | Why not |
+|---|---|
+| OpenAI Whisper API ($0.006/min) | Audio leaves the cluster; defeats the homelab/privacy point. |
+| Deepgram / AssemblyAI streaming | External, paid, lowest latency — keep as a fallback option, not the default. |
+| faster-whisper (CTranslate2) | Faster per watt on CPU, but adds a Python sidecar. Only worth it if `base.en` can't keep up; revisit then. |
+| `small` / `medium` / `large` whisper | RAM and CPU cost outside the "low-cost hardware" envelope. |
+
+### Settling latency vs accuracy at runtime
+
+Make the model a config knob on the whisper Deployment (`WHISPER_MODEL=base.en`),
+not a build-time decision. The model file lives on a PVC so swapping it is a
+restart, not a rebuild.
 
 ## 4. Audio plumbing details
 
@@ -127,10 +164,13 @@ Sessions are keyed by `(guild_id, channel_id, started_at)`.
 Two new workloads in the `rankore` namespace:
 
 - `whisper` Deployment + Service
-  - image: `ghcr.io/ggerganov/whisper.cpp:server` (or a self-built image with
-    a particular model baked in)
-  - PVC for the model file (avoids re-downloading on restart)
-  - resources: 2 vCPU / 4Gi for `small`, 4 vCPU / 8Gi for `medium`
+  - image: `ghcr.io/ggerganov/whisper.cpp:server` (or a self-built thin image)
+  - PVC for the model file (~60 MB for `base.en` Q5_0) so the model isn't
+    re-downloaded on restart
+  - resources sized for `base.en` Q5_0:
+    - requests: 500m CPU / 256Mi RAM
+    - limits:   2 CPU / 512Mi RAM
+  - If you later swap to `small.en`, bump the limits to 4 CPU / 1Gi RAM.
 - The existing `rankore` Deployment gets a transcripts PVC mount and a
   `WHISPER_URL=http://whisper:9000` env var.
 
@@ -187,8 +227,9 @@ phases 4–6 are smaller polish (~1 week combined).
 - **Discord ToS / privacy law.** Mitigation: explicit consent banner,
   per-user opt-out, no raw audio retention by default, clear documentation
   of retention.
-- **Memory.** whisper-small: ~500MB resident; whisper-medium: ~1.5GB. Sized
-  in the k8s resources.
+- **Memory.** Recommended `base.en` Q5_0: ~140 MB resident. `small.en` Q5_0:
+  ~500 MB. `medium` and up are intentionally out of scope for the homelab
+  hardware budget.
 - **serenity 0.11 EOL.** Newer songbird requires serenity 0.12+. If we have
   to upgrade serenity, the bulk of the bot code stays the same but the
   builder APIs and some event signatures change. Worth scoping that upgrade

--- a/k8s/.gitignore
+++ b/k8s/.gitignore
@@ -1,0 +1,1 @@
+10-secrets.yaml

--- a/k8s/00-namespace.yaml
+++ b/k8s/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rankore

--- a/k8s/10-secrets.example.yaml
+++ b/k8s/10-secrets.example.yaml
@@ -1,0 +1,35 @@
+# Template — copy to 10-secrets.yaml, fill in real values, and DO NOT commit
+# the filled copy (it's gitignored via k8s/.gitignore).
+#
+#   cp k8s/10-secrets.example.yaml k8s/10-secrets.yaml
+#   $EDITOR k8s/10-secrets.yaml
+#   kubectl apply -f k8s/10-secrets.yaml
+#
+# If the GHCR image is private, also create an image-pull secret (run once):
+#
+#   kubectl -n rankore create secret docker-registry ghcr-pull \
+#     --docker-server=ghcr.io \
+#     --docker-username=<gh-username> \
+#     --docker-password=<gh-pat-with-read:packages>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rankore-bot
+  namespace: rankore
+type: Opaque
+stringData:
+  DISCORD_TOKEN: "REPLACE_ME"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rankore-postgres
+  namespace: rankore
+type: Opaque
+stringData:
+  POSTGRES_USER: "rankore"
+  POSTGRES_PASSWORD: "REPLACE_ME"
+  POSTGRES_DB: "rankore"
+  # Consumed by the bot. Hostname is the Service name below.
+  DATABASE_URL: "postgres://rankore:REPLACE_ME@rankore-postgres:5432/rankore"

--- a/k8s/20-postgres.yaml
+++ b/k8s/20-postgres.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rankore-postgres
+  namespace: rankore
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: rankore-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rankore-postgres
+  namespace: rankore
+spec:
+  serviceName: rankore-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rankore-postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rankore-postgres
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: rankore-postgres
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rankore-postgres
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: rankore-postgres
+                  key: POSTGRES_DB
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "rankore", "-d", "rankore"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "rankore", "-d", "rankore"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-path-ssd
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/30-bot.yaml
+++ b/k8s/30-bot.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rankore
+  namespace: rankore
+  labels:
+    app.kubernetes.io/name: rankore
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rankore
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rankore
+    spec:
+      # Uncomment if the GHCR image is private:
+      # imagePullSecrets:
+      #   - name: ghcr-pull
+      containers:
+        - name: rankore
+          image: ghcr.io/fulviodenza/rankore:latest
+          imagePullPolicy: Always
+          env:
+            - name: DISCORD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: rankore-bot
+                  key: DISCORD_TOKEN
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: rankore-postgres
+                  key: DATABASE_URL
+            - name: RUST_BACKTRACE
+              value: "1"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 15

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,92 @@
+# Rankore — Kubernetes deployment
+
+Single-node-friendly manifests targeting the k3s cluster in `~/.kube/config`.
+Postgres is bundled as a StatefulSet in the `rankore` namespace; the bot image
+is pulled from GHCR.
+
+## Prerequisites
+
+- A k3s/Kubernetes cluster with at least one node and the `local-path-ssd`
+  storage class (substitute another class in `20-postgres.yaml` if needed).
+- A Discord bot token.
+- An image pushed to `ghcr.io/fulviodenza/rankore`.
+
+## Build and push the image
+
+From the repo root:
+
+```sh
+# Multi-arch is nice but not required for a single-node cluster.
+docker build -t ghcr.io/fulviodenza/rankore:latest .
+
+# Authenticate against GHCR (one-time):
+echo "$GH_PAT" | docker login ghcr.io -u fulviodenza --password-stdin
+
+docker push ghcr.io/fulviodenza/rankore:latest
+```
+
+Tag with a SHA or semver for production rollouts:
+`ghcr.io/fulviodenza/rankore:$(git rev-parse --short HEAD)`.
+
+## Apply
+
+```sh
+kubectl apply -f k8s/00-namespace.yaml
+
+# Fill in the secrets template, then apply (do not commit the filled copy):
+cp k8s/10-secrets.example.yaml k8s/10-secrets.yaml
+$EDITOR k8s/10-secrets.yaml
+kubectl apply -f k8s/10-secrets.yaml
+
+# If the GHCR image is private, also create an image-pull secret:
+kubectl -n rankore create secret docker-registry ghcr-pull \
+  --docker-server=ghcr.io \
+  --docker-username=fulviodenza \
+  --docker-password=$GH_PAT_READ_PACKAGES
+# then uncomment `imagePullSecrets` in 30-bot.yaml.
+
+kubectl apply -f k8s/20-postgres.yaml
+kubectl -n rankore rollout status statefulset/rankore-postgres --timeout=120s
+
+kubectl apply -f k8s/30-bot.yaml
+kubectl -n rankore rollout status deployment/rankore --timeout=120s
+```
+
+## Verify
+
+```sh
+kubectl -n rankore get pods
+kubectl -n rankore logs deploy/rankore -f
+```
+
+The bot runs migrations on startup via `sqlx::migrate!()`, so the first
+deployment creates the schema automatically. Subsequent deploys re-run only
+pending migrations.
+
+## Upgrade
+
+```sh
+docker build -t ghcr.io/fulviodenza/rankore:$(git rev-parse --short HEAD) .
+docker push ghcr.io/fulviodenza/rankore:$(git rev-parse --short HEAD)
+kubectl -n rankore set image deployment/rankore \
+  rankore=ghcr.io/fulviodenza/rankore:$(git rev-parse --short HEAD)
+kubectl -n rankore rollout status deployment/rankore
+```
+
+## Tear down
+
+```sh
+kubectl delete namespace rankore
+# Note: the PVC for Postgres is in the namespace and will be deleted too.
+# Back up the data first if you care about it.
+```
+
+## Notes
+
+- The bot runs as a single replica (`strategy: Recreate`). Discord bots cannot
+  shard from a single token without explicit sharding setup, and this bot does
+  not.
+- No HTTP liveness probe. The container is alive iff the Rust process is
+  running; k8s will restart on crash.
+- `DATABASE_URL` lives in the `rankore-postgres` secret rather than the bot's
+  own secret, so the password is defined exactly once.

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,6 +196,10 @@ async fn main() {
         }
     };
 
+    if let Err(e) = sqlx::migrate!("./migrations").run(&pool).await {
+        panic!("failed to run migrations: {e}");
+    }
+
     let token = env::var("DISCORD_TOKEN").expect("Expected a token for discord in the environment");
     let intents = GatewayIntents::GUILD_MESSAGES
         | GatewayIntents::MESSAGE_CONTENT


### PR DESCRIPTION
## Summary

Adds Kubernetes deployment scaffolding and a design doc for voice transcription. Stacks on top of #34 (senior-review-fixes); merge that first.

### Deployment

- `src/main.rs`: run `sqlx::migrate!()` on startup so a fresh database self-bootstraps. Migrations are baked into the binary at compile time, no runtime file access.
- `Dockerfile`: multi-stage build with a slim Debian runtime; includes the `migrations/` dir in the builder stage.
- `k8s/`:
  - `00-namespace.yaml` — `rankore` namespace
  - `10-secrets.example.yaml` — template for `rankore-bot` (DISCORD_TOKEN) and `rankore-postgres` (POSTGRES_* + DATABASE_URL). Real values not committed (`k8s/.gitignore`).
  - `20-postgres.yaml` — bundled Postgres StatefulSet + headless Service, `local-path-ssd` PVC, `pg_isready` probes
  - `30-bot.yaml` — bot Deployment, env from secrets, modest resource requests/limits, `strategy: Recreate` (single replica)
  - `README.md` — build / push (GHCR) / apply / upgrade / tear-down

Validates with `kubectl --dry-run=client`.

### Transcription plan

`docs/transcription-plan.md` covers:
- Constraints: songbird voice receive (unofficial), serenity 0.11 ↔ songbird 0.3 coupling, consent
- Architecture: bot ⇄ separate whisper.cpp service in-cluster; per-user Opus demux → PCM → 16kHz mono → VAD segmenter → STT → transcript file on PVC
- Engine tradeoffs (whisper.cpp vs OpenAI vs Deepgram vs faster-whisper) — recommends whisper.cpp self-hosted
- Discord UX: `!transcribe_join` / `!transcribe_leave` / `!transcribe_status` / opt-in/opt-out
- K8s shape: whisper Deployment + model PVC; transcripts PVC in the bot
- 6-phase rollout, risks, out-of-scope items

## Test plan

- [ ] `cargo check` passes offline (verified)
- [ ] `kubectl apply --dry-run=client` against all manifests (verified)
- [ ] Build the image, push to GHCR, fill in `10-secrets.yaml`, apply, watch logs
- [ ] First-deploy: verify migrations run and the schema is created
- [ ] Send a message in a guild, run `!leaderboard`, verify scoring works end-to-end against the bundled Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)