### PR TITLE
feat(commands): support slash commands alongside prefix commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ screen ./run.sh
 
 
 ## Commands
+All commands below work as **slash commands** (`/leaderboard`, `/help`, …) and as classic prefix commands using the server's prefix (default `!`).
+
 - `!leaderboard`: List the users and their points, from the most active to the less active;
 - `!download_leaderboard`: get a file .xlsx containing a table with all the users and related scores
 - `!set_prefix [PREFIX]`: Set the prefix for the Discord server in which the bot is running; (After this command the default `!` prefix will not be active, replaced by the one you set)

--- a/assets/help.md
+++ b/assets/help.md
@@ -6,6 +6,8 @@ This bot is currently tracking voice and text user activity into a Discord serve
  or Join the official [rankore Discord server](https://discord.gg/RezDWZwKCT)!
  
 ## Commands
+All commands are available as **slash commands** (`/leaderboard`, `/help`, …) and as classic prefix commands (`!leaderboard`, or your custom prefix).
+
 - `!leaderboard`: List the users and their points, from the most active to the less active;
 - `!download_leaderboard`: get a file .xlsx containing a table with all the users and related scores
 - `!set_prefix [PREFIX]`: Set the prefix for the Discord server in which the bot is running; (After this command the default `!` prefix will not be active, replaced by the one you set)

--- a/src/commands/download_leaderboard.rs
+++ b/src/commands/download_leaderboard.rs
@@ -12,8 +12,10 @@ use crate::{
 
 const LEADERBOARD_LIMIT: i64 = 10_000;
 
-#[poise::command(prefix_command, guild_only)]
+#[poise::command(prefix_command, slash_command, guild_only)]
 pub async fn download_leaderboard(ctx: Context<'_>) -> Result<(), Error> {
+    // xlsx generation + upload can exceed the 3s slash-command ack window.
+    ctx.defer().await?;
     let guild_id = ctx.guild_id().unwrap().get() as i64;
     let users = match ctx
         .data()

--- a/src/commands/get_prefix.rs
+++ b/src/commands/get_prefix.rs
@@ -1,6 +1,6 @@
 use crate::{db::guilds::GuildRepo, Context, Error};
 
-#[poise::command(prefix_command, guild_only)]
+#[poise::command(prefix_command, slash_command, guild_only)]
 pub async fn get_prefix(ctx: Context<'_>) -> Result<(), Error> {
     let guild_id = ctx.guild_id().unwrap().get() as i64;
     let prefix = ctx.data().guilds.get_prefix(guild_id).await;

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -4,7 +4,7 @@ use std::fs;
 
 use crate::{Context, Error};
 
-#[poise::command(prefix_command)]
+#[poise::command(prefix_command, slash_command)]
 pub async fn help(ctx: Context<'_>) -> Result<(), Error> {
     let body = fs::read_to_string("./assets/help.md")
         .unwrap_or_else(|_| "Help file not available.".to_string());

--- a/src/commands/leaderboard.rs
+++ b/src/commands/leaderboard.rs
@@ -5,7 +5,7 @@ use crate::{db::users::UsersRepo, Context, Error};
 
 const LEADERBOARD_LIMIT: i64 = 100;
 
-#[poise::command(prefix_command, guild_only)]
+#[poise::command(prefix_command, slash_command, guild_only)]
 pub async fn leaderboard(ctx: Context<'_>) -> Result<(), Error> {
     let guild_id = ctx.guild_id().unwrap().get() as i64;
     let users = match ctx

--- a/src/commands/multipliers.rs
+++ b/src/commands/multipliers.rs
@@ -3,7 +3,7 @@ use serenity::all::CreateEmbed;
 
 use crate::{db::guilds::GuildRepo, Context, Error};
 
-#[poise::command(prefix_command, guild_only)]
+#[poise::command(prefix_command, slash_command, guild_only)]
 pub async fn multipliers(ctx: Context<'_>) -> Result<(), Error> {
     let guild_id = ctx.guild_id().unwrap().get() as i64;
     let text = ctx.data().guilds.get_text_multiplier(guild_id).await;

--- a/src/commands/reset_scores.rs
+++ b/src/commands/reset_scores.rs
@@ -2,6 +2,7 @@ use crate::{db::users::UsersRepo, Context, Error};
 
 #[poise::command(
     prefix_command,
+    slash_command,
     required_permissions = "ADMINISTRATOR",
     guild_only
 )]

--- a/src/commands/set_prefix.rs
+++ b/src/commands/set_prefix.rs
@@ -2,6 +2,7 @@ use crate::{db::guilds::GuildRepo, Context, Error};
 
 #[poise::command(
     prefix_command,
+    slash_command,
     required_permissions = "ADMINISTRATOR",
     guild_only
 )]

--- a/src/commands/set_text_multiplier.rs
+++ b/src/commands/set_text_multiplier.rs
@@ -2,6 +2,7 @@ use crate::{db::guilds::GuildRepo, Context, Error};
 
 #[poise::command(
     prefix_command,
+    slash_command,
     required_permissions = "ADMINISTRATOR",
     guild_only
 )]

--- a/src/commands/set_voice_multiplier.rs
+++ b/src/commands/set_voice_multiplier.rs
@@ -2,6 +2,7 @@ use crate::{db::guilds::GuildRepo, Context, Error};
 
 #[poise::command(
     prefix_command,
+    slash_command,
     required_permissions = "ADMINISTRATOR",
     guild_only
 )]

--- a/src/commands/set_welcome_msg.rs
+++ b/src/commands/set_welcome_msg.rs
@@ -2,6 +2,7 @@ use crate::{db::guilds::GuildRepo, Context, Error};
 
 #[poise::command(
     prefix_command,
+    slash_command,
     required_permissions = "ADMINISTRATOR",
     guild_only
 )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,8 +109,9 @@ async fn main() {
             },
             ..Default::default()
         })
-        .setup(move |_ctx, _ready, _framework| {
+        .setup(move |ctx, _ready, framework| {
             Box::pin(async move {
+                poise::builtins::register_globally(ctx, &framework.options().commands).await?;
                 Ok(Data {
                     guilds,
                     users,


### PR DESCRIPTION
## Summary
- Add `slash_command` to every `#[poise::command(...)]` so each command now works as both `/cmd` and `!cmd`.
- Register slash commands globally in the poise `setup` closure via `poise::builtins::register_globally`.
- Defer `download_leaderboard` before generating/uploading the xlsx so the slash invocation does not exceed the 3s ack window.
- Note dual-mode availability in `README.md` and `assets/help.md`.

Motivation: Discord is deprecating the `MESSAGE_CONTENT` intent for verified bots; prefix commands will stop working at scale without it. This unblocks every future feature.

## Test plan
- [ ] `cargo check` passes (verified locally).
- [ ] Invite the bot to a test guild and confirm `/leaderboard`, `/help`, `/multipliers` work without `!`.
- [ ] Run `/download_leaderboard` and confirm the xlsx attaches even when generation takes >3s.
- [ ] Run `!leaderboard` and confirm prefix mode still works.
- [ ] Confirm admin-gated slash commands (`/reset_scores`, `/set_prefix`, …) honor the `ADMINISTRATOR` permission requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)