### PR TITLE
feat(roles): auto-grant roles at score thresholds

### DIFF
--- a/.sqlx/query-2d538c10624f6637d6abf55c352063c8d873d0b901be7ea8cb46ccda43148250.json
+++ b/.sqlx/query-2d538c10624f6637d6abf55c352063c8d873d0b901be7ea8cb46ccda43148250.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT role_id FROM role_thresholds WHERE guild_id = $1 AND score <= $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "role_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2d538c10624f6637d6abf55c352063c8d873d0b901be7ea8cb46ccda43148250"
+}

--- a/.sqlx/query-5eb042a90cc605ceae158a0dc8cbf9f48fecb4959355fbef68d3f817ccba6809.json
+++ b/.sqlx/query-5eb042a90cc605ceae158a0dc8cbf9f48fecb4959355fbef68d3f817ccba6809.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM role_thresholds WHERE guild_id = $1 AND role_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5eb042a90cc605ceae158a0dc8cbf9f48fecb4959355fbef68d3f817ccba6809"
+}

--- a/.sqlx/query-60e91b877b75bdc34b9d48dc1ef35f4e304c50578efd091eb71aa9e69010958e.json
+++ b/.sqlx/query-60e91b877b75bdc34b9d48dc1ef35f4e304c50578efd091eb71aa9e69010958e.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT role_id, score FROM role_thresholds WHERE guild_id = $1 ORDER BY score ASC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "role_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "score",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "60e91b877b75bdc34b9d48dc1ef35f4e304c50578efd091eb71aa9e69010958e"
+}

--- a/.sqlx/query-9d480c18467b18cff5ce64dab54b2761ee597688d5eae27565729a4762b6767c.json
+++ b/.sqlx/query-9d480c18467b18cff5ce64dab54b2761ee597688d5eae27565729a4762b6767c.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT score FROM users WHERE id = $1 AND guild_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "score",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9d480c18467b18cff5ce64dab54b2761ee597688d5eae27565729a4762b6767c"
+}

--- a/.sqlx/query-cb650fc39dfb78d30facd15c31e457f1a9b77f25d448fb2468a477cf49b5eb3c.json
+++ b/.sqlx/query-cb650fc39dfb78d30facd15c31e457f1a9b77f25d448fb2468a477cf49b5eb3c.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO role_thresholds (guild_id, role_id, score) VALUES ($1, $2, $3) ON CONFLICT (guild_id, role_id) DO UPDATE SET score = EXCLUDED.score",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cb650fc39dfb78d30facd15c31e457f1a9b77f25d448fb2468a477cf49b5eb3c"
+}

--- a/migrations/20260629000001_role_thresholds.sql
+++ b/migrations/20260629000001_role_thresholds.sql
@@ -1,0 +1,7 @@
+CREATE TABLE role_thresholds (
+    guild_id BIGINT NOT NULL,
+    role_id BIGINT NOT NULL,
+    score BIGINT NOT NULL,
+    PRIMARY KEY (guild_id, role_id)
+);
+CREATE INDEX role_thresholds_guild_score_idx ON role_thresholds (guild_id, score);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod help;
 pub mod leaderboard;
 pub mod multipliers;
 pub mod reset_scores;
+pub mod role_thresholds;
 pub mod set_prefix;
 pub mod set_text_multiplier;
 pub mod set_voice_multiplier;

--- a/src/commands/role_thresholds.rs
+++ b/src/commands/role_thresholds.rs
@@ -1,0 +1,97 @@
+use poise::CreateReply;
+use serenity::all::{CreateEmbed, Role};
+
+use crate::{
+    db::roles::RolesRepo,
+    Context, Error,
+};
+
+/// Configure roles that are granted automatically when users hit score thresholds.
+#[poise::command(
+    prefix_command,
+    slash_command,
+    required_permissions = "ADMINISTRATOR",
+    guild_only,
+    subcommands("set", "remove", "list")
+)]
+pub async fn role_thresholds(_ctx: Context<'_>) -> Result<(), Error> {
+    Ok(())
+}
+
+/// Grant a role automatically when a user reaches `score` points.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn set(
+    ctx: Context<'_>,
+    #[description = "Role to grant"] role: Role,
+    #[description = "Score threshold (positive integer)"] score: i64,
+) -> Result<(), Error> {
+    if score < 0 {
+        ctx.say("score threshold must be non-negative").await?;
+        return Ok(());
+    }
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let reply = match ctx
+        .data()
+        .roles
+        .set_threshold(guild_id, role.id.get() as i64, score)
+        .await
+    {
+        Ok(()) => format!("set threshold: {} at {} points", role.name, score),
+        Err(e) => {
+            eprintln!("[role_thresholds set] db error: {e}");
+            "failed to set threshold".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}
+
+/// Remove the threshold for a role.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn remove(
+    ctx: Context<'_>,
+    #[description = "Role to stop auto-granting"] role: Role,
+) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let reply = match ctx
+        .data()
+        .roles
+        .remove_threshold(guild_id, role.id.get() as i64)
+        .await
+    {
+        Ok(()) => format!("removed threshold for {}", role.name),
+        Err(e) => {
+            eprintln!("[role_thresholds remove] db error: {e}");
+            "failed to remove threshold".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}
+
+/// List configured role thresholds for this guild.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn list(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let rows = match ctx.data().roles.list_thresholds(guild_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("[role_thresholds list] db error: {e}");
+            ctx.say("failed to list thresholds").await?;
+            return Ok(());
+        }
+    };
+    let body = if rows.is_empty() {
+        "(none configured)".to_string()
+    } else {
+        rows.into_iter()
+            .map(|t| format!("- <@&{}> at {} points\n", t.role_id, t.score))
+            .collect()
+    };
+    let embed = CreateEmbed::new()
+        .title("role thresholds")
+        .description(body)
+        .colour((58, 8, 9));
+    ctx.send(CreateReply::default().embed(embed).reply(true)).await?;
+    Ok(())
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,4 @@
 pub mod events;
 pub mod guilds;
+pub mod roles;
 pub mod users;

--- a/src/db/roles.rs
+++ b/src/db/roles.rs
@@ -1,0 +1,102 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sqlx::{Error, Pool, Postgres};
+
+pub struct Roles {
+    pub pool: Pool<Postgres>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RoleThreshold {
+    pub role_id: i64,
+    pub score: i64,
+}
+
+#[async_trait]
+pub trait RolesRepo {
+    async fn new(pool: &Pool<Postgres>) -> Arc<Self>;
+    async fn set_threshold(
+        &self,
+        guild_id: i64,
+        role_id: i64,
+        score: i64,
+    ) -> Result<(), Error>;
+    async fn remove_threshold(&self, guild_id: i64, role_id: i64) -> Result<(), Error>;
+    async fn list_thresholds(&self, guild_id: i64) -> Result<Vec<RoleThreshold>, Error>;
+    async fn earned_roles(
+        &self,
+        guild_id: i64,
+        score: i64,
+    ) -> Result<Vec<i64>, Error>;
+}
+
+#[async_trait]
+impl RolesRepo for Roles {
+    async fn new(pool: &Pool<Postgres>) -> Arc<Self> {
+        Arc::new(Roles { pool: pool.clone() })
+    }
+
+    async fn set_threshold(
+        &self,
+        guild_id: i64,
+        role_id: i64,
+        score: i64,
+    ) -> Result<(), Error> {
+        sqlx::query!(
+            "INSERT INTO role_thresholds (guild_id, role_id, score) \
+             VALUES ($1, $2, $3) \
+             ON CONFLICT (guild_id, role_id) DO UPDATE SET score = EXCLUDED.score",
+            guild_id,
+            role_id,
+            score,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn remove_threshold(&self, guild_id: i64, role_id: i64) -> Result<(), Error> {
+        sqlx::query!(
+            "DELETE FROM role_thresholds WHERE guild_id = $1 AND role_id = $2",
+            guild_id,
+            role_id,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn list_thresholds(&self, guild_id: i64) -> Result<Vec<RoleThreshold>, Error> {
+        let rows = sqlx::query!(
+            "SELECT role_id, score FROM role_thresholds \
+             WHERE guild_id = $1 ORDER BY score ASC",
+            guild_id,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| RoleThreshold {
+                role_id: r.role_id,
+                score: r.score,
+            })
+            .collect())
+    }
+
+    async fn earned_roles(
+        &self,
+        guild_id: i64,
+        score: i64,
+    ) -> Result<Vec<i64>, Error> {
+        let rows = sqlx::query!(
+            "SELECT role_id FROM role_thresholds \
+             WHERE guild_id = $1 AND score <= $2",
+            guild_id,
+            score,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|r| r.role_id).collect())
+    }
+}

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -10,10 +10,12 @@ use tokio::{
 };
 
 use super::events::{Observer, UserEvents};
+use crate::services::roles::RoleSyncer;
 
 pub struct Users {
     pub pool: Pool<Postgres>,
     pub tx: UnboundedSender<UserEvents>,
+    pub role_syncer: Arc<RoleSyncer>,
 }
 
 #[allow(dead_code)]
@@ -29,7 +31,7 @@ pub struct User {
 
 #[async_trait]
 pub trait UsersRepo {
-    async fn new(pool: &Pool<Postgres>) -> Arc<Self>;
+    async fn new(pool: &Pool<Postgres>, role_syncer: Arc<RoleSyncer>) -> Arc<Self>;
     async fn increment_score(
         pool: &Pool<Postgres>,
         id: i64,
@@ -45,11 +47,12 @@ pub trait UsersRepo {
 
 #[async_trait]
 impl UsersRepo for Users {
-    async fn new(pool: &Pool<Postgres>) -> Arc<Self> {
+    async fn new(pool: &Pool<Postgres>, role_syncer: Arc<RoleSyncer>) -> Arc<Self> {
         let (tx, rx) = mpsc::unbounded_channel::<UserEvents>();
         let users = Arc::new(Users {
             tx,
             pool: pool.clone(),
+            role_syncer,
         });
         let users_clone = Arc::clone(&users);
         tokio::spawn(async move {
@@ -151,14 +154,16 @@ impl Observer for Users {
 
                     let pool = self.pool.clone();
                     let tickers = tickers.clone();
+                    let role_syncer = self.role_syncer.clone();
                     tokio::spawn(async move {
                         loop {
                             select! {
                                 _ = tokio::time::sleep(tokio::time::Duration::from_secs(interval)) => {
-                                    if let Err(e) = Users::increment_score(
+                                    match Users::increment_score(
                                         &pool, user_id, guild_id, &nick, is_bot, 1,
                                     ).await {
-                                        eprintln!("[voice tick] increment_score failed: {e}");
+                                        Ok(()) => role_syncer.sync(user_id, guild_id).await,
+                                        Err(e) => eprintln!("[voice tick] increment_score failed: {e}"),
                                     }
                                 }
                                 _ = &mut cancel_rx => break,
@@ -182,11 +187,13 @@ impl Observer for Users {
                     }
                 }
                 UserEvents::SentText(user_id, nick, is_bot, guild_id, delta) => {
-                    if let Err(e) =
-                        Users::increment_score(&self.pool, user_id, guild_id, &nick, is_bot, delta)
-                            .await
+                    match Users::increment_score(
+                        &self.pool, user_id, guild_id, &nick, is_bot, delta,
+                    )
+                    .await
                     {
-                        eprintln!("[SentText] increment_score failed: {e}");
+                        Ok(()) => self.role_syncer.sync(user_id, guild_id).await,
+                        Err(e) => eprintln!("[SentText] increment_score failed: {e}"),
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,14 @@ use std::{
 
 use db::{
     guilds::{GuildRepo, Guilds},
+    roles::{Roles, RolesRepo},
     users::{Users, UsersRepo},
 };
 use serenity::{
-    all::{ChannelType, FullEvent, GatewayIntents, GuildId},
+    all::{ChannelType, FullEvent, GatewayIntents, GuildId, Http},
     Client,
 };
+use services::roles::RoleSyncer;
 use sqlx::postgres::PgPoolOptions;
 use tokio::sync::Mutex;
 
@@ -26,6 +28,7 @@ pub type Context<'a> = poise::Context<'a, Data, Error>;
 pub struct Data {
     pub guilds: Arc<Guilds>,
     pub users: Arc<Users>,
+    pub roles: Arc<Roles>,
     pub active_users: Arc<Mutex<HashSet<(i64, i64)>>>,
 }
 
@@ -75,8 +78,11 @@ async fn main() {
         | GatewayIntents::GUILD_VOICE_STATES
         | GatewayIntents::GUILD_MEMBERS;
 
+    let http = Arc::new(Http::new(&token));
     let guilds = Guilds::new(&pool).await;
-    let users = Users::new(&pool).await;
+    let roles = Roles::new(&pool).await;
+    let role_syncer = RoleSyncer::new(http.clone(), pool.clone(), roles.clone());
+    let users = Users::new(&pool, role_syncer).await;
     let active_users = Arc::new(Mutex::new(HashSet::new()));
 
     let framework = poise::Framework::builder()
@@ -92,6 +98,7 @@ async fn main() {
                 commands::set_text_multiplier::set_text_multiplier(),
                 commands::multipliers::multipliers(),
                 commands::download_leaderboard::download_leaderboard(),
+                commands::role_thresholds::role_thresholds(),
             ],
             prefix_options: poise::PrefixFrameworkOptions {
                 dynamic_prefix: Some(|ctx| {
@@ -115,6 +122,7 @@ async fn main() {
                 Ok(Data {
                     guilds,
                     users,
+                    roles,
                     active_users,
                 })
             })

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod message;
+pub mod roles;

--- a/src/services/roles.rs
+++ b/src/services/roles.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use serenity::all::{GuildId, Http, RoleId, UserId};
+use sqlx::{Pool, Postgres};
+
+use crate::db::roles::{Roles, RolesRepo};
+
+pub struct RoleSyncer {
+    pub http: Arc<Http>,
+    pub pool: Pool<Postgres>,
+    pub roles: Arc<Roles>,
+}
+
+impl RoleSyncer {
+    pub fn new(http: Arc<Http>, pool: Pool<Postgres>, roles: Arc<Roles>) -> Arc<Self> {
+        Arc::new(Self { http, pool, roles })
+    }
+
+    /// Look up the user's current score for the guild and grant any threshold
+    /// roles they have earned but don't yet have. Additive only — roles are
+    /// not removed when a score drops below a threshold (e.g. after reset).
+    pub async fn sync(self: &Arc<Self>, user_id: i64, guild_id: i64) {
+        let score = match sqlx::query_scalar!(
+            "SELECT score FROM users WHERE id = $1 AND guild_id = $2",
+            user_id,
+            guild_id,
+        )
+        .fetch_optional(&self.pool)
+        .await
+        {
+            Ok(Some(s)) => s,
+            Ok(None) => return,
+            Err(e) => {
+                eprintln!("[role_sync] read score: {e}");
+                return;
+            }
+        };
+
+        let earned = match self.roles.earned_roles(guild_id, score).await {
+            Ok(r) if !r.is_empty() => r,
+            Ok(_) => return,
+            Err(e) => {
+                eprintln!("[role_sync] earned_roles: {e}");
+                return;
+            }
+        };
+
+        let gid = GuildId::new(guild_id as u64);
+        let uid = UserId::new(user_id as u64);
+        let member = match self.http.get_member(gid, uid).await {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("[role_sync] get_member: {e}");
+                return;
+            }
+        };
+        let current: std::collections::HashSet<u64> =
+            member.roles.iter().map(|r| r.get()).collect();
+        for role_id in earned {
+            let rid = role_id as u64;
+            if current.contains(&rid) {
+                continue;
+            }
+            if let Err(e) = self
+                .http
+                .add_member_role(gid, uid, RoleId::new(rid), Some("rankore score threshold"))
+                .await
+            {
+                eprintln!("[role_sync] add_member_role({rid}): {e}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Stacks on top of #40 (slash-commands). Merge that first.**

## Summary
- New `role_thresholds` table + `Roles` repo.
- `RoleSyncer` service: after a text-message score increment OR a voice-tick increment, looks up the user's current score, finds threshold roles they have earned, and grants any they don't already have via `Http::add_member_role`.
- New `/role_thresholds set @role <score>`, `/role_thresholds remove @role`, `/role_thresholds list` (admin-only, subcommand group).
- Wired `Arc<Http>` and `Arc<RoleSyncer>` through main → Users so the voice ticker can sync too.

Additive only: dropping below a threshold (e.g. after `/reset_scores`) does **not** remove the role. We can add removal logic in a follow-up if you want symmetry.

## Test plan
- [ ] Apply migration on staging.
- [ ] Configure a low threshold (e.g. 3) and send messages — verify the role is granted on the message that crosses the line.
- [ ] Join a voice channel; verify the role is granted on the tick that crosses the line.
- [ ] Confirm the bot's role is high enough in the role hierarchy to manage the target roles, and that it has the `MANAGE_ROLES` permission — otherwise `add_member_role` will 403 (logged at stderr).
- [ ] Run `/role_thresholds list` to confirm the configured set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)