### PR TITLE
feat(leaderboard): weekly and monthly leaderboards

### DIFF
--- a/.sqlx/query-f913b44da4e36f43da9da6011f9e353168fe5c285f9bb9bb27065e219b3ccf48.json
+++ b/.sqlx/query-f913b44da4e36f43da9da6011f9e353168fe5c285f9bb9bb27065e219b3ccf48.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO score_events (user_id, guild_id, delta) VALUES ($1, $2, $3)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f913b44da4e36f43da9da6011f9e353168fe5c285f9bb9bb27065e219b3ccf48"
+}

--- a/.sqlx/query-fe442c1b3360a5fe36db723c96169433dfb67d25a20b7d3ee7daa132b8499149.json
+++ b/.sqlx/query-fe442c1b3360a5fe36db723c96169433dfb67d25a20b7d3ee7daa132b8499149.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT u.id, u.nick, u.is_bot, u.guild_id, u.hasleft, COALESCE(SUM(e.delta), 0)::BIGINT AS \"period_score!\" FROM users u JOIN score_events e ON e.user_id = u.id AND e.guild_id = u.guild_id WHERE u.guild_id = $1 AND u.is_bot = false AND e.occurred_at >= $2 GROUP BY u.id, u.guild_id, u.nick, u.is_bot, u.hasleft ORDER BY \"period_score!\" DESC LIMIT $3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "nick",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "is_bot",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "guild_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "hasleft",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "period_score!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Timestamptz",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      null
+    ]
+  },
+  "hash": "fe442c1b3360a5fe36db723c96169433dfb67d25a20b7d3ee7daa132b8499149"
+}

--- a/migrations/20260629000002_score_events.sql
+++ b/migrations/20260629000002_score_events.sql
@@ -1,0 +1,11 @@
+CREATE TABLE score_events (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    guild_id BIGINT NOT NULL,
+    delta BIGINT NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX score_events_guild_time_idx
+    ON score_events (guild_id, occurred_at DESC);
+CREATE INDEX score_events_guild_user_time_idx
+    ON score_events (guild_id, user_id, occurred_at DESC);

--- a/src/commands/leaderboard.rs
+++ b/src/commands/leaderboard.rs
@@ -1,3 +1,4 @@
+use chrono::{Duration, Utc};
 use poise::CreateReply;
 use serenity::all::CreateEmbed;
 
@@ -5,27 +6,58 @@ use crate::{db::users::UsersRepo, Context, Error};
 
 const LEADERBOARD_LIMIT: i64 = 100;
 
+#[derive(Debug, poise::ChoiceParameter)]
+pub enum Period {
+    #[name = "all-time"]
+    All,
+    #[name = "week"]
+    Week,
+    #[name = "month"]
+    Month,
+}
+
 #[poise::command(prefix_command, slash_command, guild_only)]
-pub async fn leaderboard(ctx: Context<'_>) -> Result<(), Error> {
+pub async fn leaderboard(
+    ctx: Context<'_>,
+    #[description = "Time window (default: all-time)"] period: Option<Period>,
+) -> Result<(), Error> {
     let guild_id = ctx.guild_id().unwrap().get() as i64;
-    let users = match ctx
-        .data()
-        .users
-        .get_leaderboard(guild_id, LEADERBOARD_LIMIT)
-        .await
-    {
+    let period = period.unwrap_or(Period::All);
+    let users = match &period {
+        Period::All => ctx.data().users.get_leaderboard(guild_id, LEADERBOARD_LIMIT).await,
+        Period::Week => {
+            let since = Utc::now() - Duration::days(7);
+            ctx.data()
+                .users
+                .get_period_leaderboard(guild_id, since, LEADERBOARD_LIMIT)
+                .await
+        }
+        Period::Month => {
+            let since = Utc::now() - Duration::days(30);
+            ctx.data()
+                .users
+                .get_period_leaderboard(guild_id, since, LEADERBOARD_LIMIT)
+                .await
+        }
+    };
+    let users = match users {
         Ok(u) => u,
         Err(e) => {
             eprintln!("[leaderboard] db error: {e}");
             return Ok(());
         }
     };
+    let title = match period {
+        Period::All => "leaderboard (all-time)",
+        Period::Week => "leaderboard (last 7 days)",
+        Period::Month => "leaderboard (last 30 days)",
+    };
     let body = users
         .into_iter()
         .map(|u| format!("{}: {}\n", u.nick, u.score))
         .collect::<String>();
     let embed = CreateEmbed::new()
-        .title("leaderboard")
+        .title(title)
         .description(if body.is_empty() { "(empty)".to_string() } else { body })
         .colour((58, 8, 9));
     ctx.send(CreateReply::default().embed(embed).reply(true)).await?;

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -42,6 +42,12 @@ pub trait UsersRepo {
     ) -> Result<(), Error>;
     async fn mark_left(pool: &Pool<Postgres>, id: i64, guild_id: i64) -> Result<(), Error>;
     async fn get_leaderboard(&self, guild_id: i64, limit: i64) -> Result<Vec<User>, Error>;
+    async fn get_period_leaderboard(
+        &self,
+        guild_id: i64,
+        since: chrono::DateTime<chrono::Utc>,
+        limit: i64,
+    ) -> Result<Vec<User>, Error>;
     async fn reset_scores(&self, guild_id: i64) -> Result<(), Error>;
 }
 
@@ -69,6 +75,7 @@ impl UsersRepo for Users {
         is_bot: bool,
         delta: i64,
     ) -> Result<(), Error> {
+        let mut tx = pool.begin().await?;
         sqlx::query!(
             "INSERT INTO users (id, score, nick, is_bot, guild_id, hasleft) \
              VALUES ($1, $2, $3, $4, $5, false) \
@@ -83,9 +90,20 @@ impl UsersRepo for Users {
             is_bot,
             guild_id,
         )
-        .execute(pool)
-        .await
-        .map(|_| ())
+        .execute(&mut *tx)
+        .await?;
+        if !is_bot && delta > 0 {
+            sqlx::query!(
+                "INSERT INTO score_events (user_id, guild_id, delta) \
+                 VALUES ($1, $2, $3)",
+                id,
+                guild_id,
+                delta,
+            )
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await
     }
 
     async fn mark_left(pool: &Pool<Postgres>, id: i64, guild_id: i64) -> Result<(), Error> {
@@ -117,6 +135,42 @@ impl UsersRepo for Users {
             .map(|row| User {
                 id: row.id,
                 score: row.score,
+                nick: row.nick,
+                is_bot: row.is_bot,
+                guild_id: row.guild_id,
+                has_left: row.hasleft.unwrap_or(false),
+            })
+            .collect())
+    }
+
+    async fn get_period_leaderboard(
+        &self,
+        guild_id: i64,
+        since: chrono::DateTime<chrono::Utc>,
+        limit: i64,
+    ) -> Result<Vec<User>, Error> {
+        let rows = sqlx::query!(
+            "SELECT u.id, u.nick, u.is_bot, u.guild_id, u.hasleft, \
+                    COALESCE(SUM(e.delta), 0)::BIGINT AS \"period_score!\" \
+             FROM users u \
+             JOIN score_events e \
+               ON e.user_id = u.id AND e.guild_id = u.guild_id \
+             WHERE u.guild_id = $1 AND u.is_bot = false AND e.occurred_at >= $2 \
+             GROUP BY u.id, u.guild_id, u.nick, u.is_bot, u.hasleft \
+             ORDER BY \"period_score!\" DESC \
+             LIMIT $3",
+            guild_id,
+            since,
+            limit,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| User {
+                id: row.id,
+                score: row.period_score,
                 nick: row.nick,
                 is_bot: row.is_bot,
                 guild_id: row.guild_id,


### PR DESCRIPTION
**Stacks on top of #41. Merge that first.**

## Summary
- New `score_events` table — every non-bot score increment inserts a row alongside the running `users.score` update (single transaction).
- `users::get_period_leaderboard(guild_id, since, limit)` aggregates `SUM(delta)` over a time window.
- `/leaderboard` now takes an optional `period` choice param: `all-time` (default), `week` (last 7d), `month` (last 30d).

The all-time path is unchanged for backwards compatibility — the new event log only affects period queries.

## Test plan
- [ ] Apply migration on staging.
- [ ] Send a few messages; run `/leaderboard period:week` and verify the user appears with the right count.
- [ ] Verify `/leaderboard` (no period) still returns the old running totals.
- [ ] Backfill consideration: existing users have no `score_events` rows, so `period:week` will appear empty until they're active again. That's intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)