### PR TITLE
feat(streaks): daily activity streaks

### DIFF
--- a/.sqlx/query-a7e7745fc02ba46b73c552d94043e992ea59101780c28edca33b58e6d3f3e58d.json
+++ b/.sqlx/query-a7e7745fc02ba46b73c552d94043e992ea59101780c28edca33b58e6d3f3e58d.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO daily_activity (user_id, guild_id, day) VALUES ($1, $2, (NOW() AT TIME ZONE 'UTC')::date) ON CONFLICT DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a7e7745fc02ba46b73c552d94043e992ea59101780c28edca33b58e6d3f3e58d"
+}

--- a/.sqlx/query-f42cf77cd63a48ae9ec6543f813a0c3bba375ed9bdbfd532085c6c9525cdd88f.json
+++ b/.sqlx/query-f42cf77cd63a48ae9ec6543f813a0c3bba375ed9bdbfd532085c6c9525cdd88f.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT day FROM daily_activity WHERE user_id = $1 AND guild_id = $2 ORDER BY day DESC LIMIT 365",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "day",
+        "type_info": "Date"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "f42cf77cd63a48ae9ec6543f813a0c3bba375ed9bdbfd532085c6c9525cdd88f"
+}

--- a/migrations/20260629000003_daily_activity.sql
+++ b/migrations/20260629000003_daily_activity.sql
@@ -1,0 +1,8 @@
+CREATE TABLE daily_activity (
+    user_id BIGINT NOT NULL,
+    guild_id BIGINT NOT NULL,
+    day DATE NOT NULL,
+    PRIMARY KEY (user_id, guild_id, day)
+);
+CREATE INDEX daily_activity_guild_day_idx
+    ON daily_activity (guild_id, day DESC);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,5 +7,6 @@ pub mod reset_scores;
 pub mod role_thresholds;
 pub mod set_prefix;
 pub mod set_text_multiplier;
+pub mod streak;
 pub mod set_voice_multiplier;
 pub mod set_welcome_msg;

--- a/src/commands/streak.rs
+++ b/src/commands/streak.rs
@@ -1,0 +1,29 @@
+use serenity::all::User;
+
+use crate::{db::users::UsersRepo, Context, Error};
+
+/// Show a user's current daily-activity streak.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn streak(
+    ctx: Context<'_>,
+    #[description = "User to check (defaults to you)"] user: Option<User>,
+) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let target = user.unwrap_or_else(|| ctx.author().clone());
+    let target_id = target.id.get() as i64;
+    let streak = match ctx.data().users.get_streak(target_id, guild_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[streak] db error: {e}");
+            ctx.say("failed to read streak").await?;
+            return Ok(());
+        }
+    };
+    let body = match streak {
+        0 => format!("{} has no active streak.", target.name),
+        1 => format!("{} is on a 1-day streak.", target.name),
+        n => format!("{} is on a {}-day streak.", target.name, n),
+    };
+    ctx.say(body).await?;
+    Ok(())
+}

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -49,6 +49,7 @@ pub trait UsersRepo {
         limit: i64,
     ) -> Result<Vec<User>, Error>;
     async fn reset_scores(&self, guild_id: i64) -> Result<(), Error>;
+    async fn get_streak(&self, user_id: i64, guild_id: i64) -> Result<i64, Error>;
 }
 
 #[async_trait]
@@ -99,6 +100,15 @@ impl UsersRepo for Users {
                 id,
                 guild_id,
                 delta,
+            )
+            .execute(&mut *tx)
+            .await?;
+            sqlx::query!(
+                "INSERT INTO daily_activity (user_id, guild_id, day) \
+                 VALUES ($1, $2, (NOW() AT TIME ZONE 'UTC')::date) \
+                 ON CONFLICT DO NOTHING",
+                id,
+                guild_id,
             )
             .execute(&mut *tx)
             .await?;
@@ -184,6 +194,41 @@ impl UsersRepo for Users {
             .execute(&self.pool)
             .await
             .map(|_| ())
+    }
+
+    async fn get_streak(&self, user_id: i64, guild_id: i64) -> Result<i64, Error> {
+        let days: Vec<chrono::NaiveDate> = sqlx::query_scalar!(
+            "SELECT day FROM daily_activity \
+             WHERE user_id = $1 AND guild_id = $2 \
+             ORDER BY day DESC \
+             LIMIT 365",
+            user_id,
+            guild_id,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        if days.is_empty() {
+            return Ok(0);
+        }
+        let today = chrono::Utc::now().date_naive();
+        let yesterday = today - chrono::Duration::days(1);
+        let mut expected = if days[0] == today {
+            today
+        } else if days[0] == yesterday {
+            yesterday
+        } else {
+            return Ok(0);
+        };
+        let mut streak: i64 = 0;
+        for d in days {
+            if d == expected {
+                streak += 1;
+                expected -= chrono::Duration::days(1);
+            } else if d < expected {
+                break;
+            }
+        }
+        Ok(streak)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,7 @@ async fn main() {
                 commands::multipliers::multipliers(),
                 commands::download_leaderboard::download_leaderboard(),
                 commands::role_thresholds::role_thresholds(),
+                commands::streak::streak(),
             ],
             prefix_options: poise::PrefixFrameworkOptions {
                 dynamic_prefix: Some(|ctx| {


### PR DESCRIPTION
**Stacks on top of #42. Merge that first.**

## Summary
- New `daily_activity` table (user_id, guild_id, day).
- `increment_score` now upserts today's row for non-bot users in the same transaction as score+score_events.
- `Users::get_streak` walks days backwards (allowing today OR yesterday as the anchor — so missing today doesn't immediately break a streak).
- New `/streak [@user]` command (defaults to caller).

## Test plan
- [ ] Apply migration.
- [ ] Send messages on consecutive days and confirm `/streak` increments.
- [ ] Skip a day and confirm `/streak` resets to 1 on the next active day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)