### PR TITLE
feat(decay): optional daily score decay

### DIFF
--- a/.sqlx/query-4ffe892431deafc694b27edc10b0acf8d9ecf47006cf5343764756a4e6099253.json
+++ b/.sqlx/query-4ffe892431deafc694b27edc10b0acf8d9ecf47006cf5343764756a4e6099253.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT * FROM guilds",
+  "query": "SELECT id, prefix, welcome_msg, voice_multiplier, text_multiplier FROM guilds",
   "describe": {
     "columns": [
       {
@@ -40,5 +40,5 @@
       false
     ]
   },
-  "hash": "fccb7063cbdd9b27e84fd16ddc8d7ddf5dfe37137fff153765d50ee298c6b32c"
+  "hash": "4ffe892431deafc694b27edc10b0acf8d9ecf47006cf5343764756a4e6099253"
 }

--- a/.sqlx/query-52e0898ffc02be3a87e4157ef8a702d2d745a81e99dae212af0c1af29a953b14.json
+++ b/.sqlx/query-52e0898ffc02be3a87e4157ef8a702d2d745a81e99dae212af0c1af29a953b14.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE users SET score = GREATEST(0, FLOOR( score::double precision * power(1.0 - $1::double precision / 100.0, $2::int) )::bigint) WHERE guild_id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Float8",
+        "Int4",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "52e0898ffc02be3a87e4157ef8a702d2d745a81e99dae212af0c1af29a953b14"
+}

--- a/.sqlx/query-54af5bd2bd86288907d79053f5ff4e1458f88b67da18f02946548dcd7974299b.json
+++ b/.sqlx/query-54af5bd2bd86288907d79053f5ff4e1458f88b67da18f02946548dcd7974299b.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE guilds SET last_decay_day = $1 WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Date",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "54af5bd2bd86288907d79053f5ff4e1458f88b67da18f02946548dcd7974299b"
+}

--- a/.sqlx/query-5efbc1b47ce2e6b4564fefbf28e2c48241cefed5e403ded94aa657d22979bac0.json
+++ b/.sqlx/query-5efbc1b47ce2e6b4564fefbf28e2c48241cefed5e403ded94aa657d22979bac0.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, decay_per_day_pct, last_decay_day FROM guilds WHERE decay_per_day_pct > 0",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "decay_per_day_pct",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_decay_day",
+        "type_info": "Date"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "5efbc1b47ce2e6b4564fefbf28e2c48241cefed5e403ded94aa657d22979bac0"
+}

--- a/.sqlx/query-d6d2199a744c2ba058310c023df6d24521720d0404ddba57304b26326ace0ad8.json
+++ b/.sqlx/query-d6d2199a744c2ba058310c023df6d24521720d0404ddba57304b26326ace0ad8.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO guilds (id, prefix, welcome_msg, voice_multiplier, text_multiplier, decay_per_day_pct) VALUES ($1, '!', '', 1, 1, $2) ON CONFLICT (id) DO UPDATE SET decay_per_day_pct = EXCLUDED.decay_per_day_pct",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d6d2199a744c2ba058310c023df6d24521720d0404ddba57304b26326ace0ad8"
+}

--- a/migrations/20260629000004_score_decay.sql
+++ b/migrations/20260629000004_score_decay.sql
@@ -1,0 +1,3 @@
+ALTER TABLE guilds
+    ADD COLUMN decay_per_day_pct INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN last_decay_day DATE;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod leaderboard;
 pub mod multipliers;
 pub mod reset_scores;
 pub mod role_thresholds;
+pub mod set_decay_rate;
 pub mod set_prefix;
 pub mod set_text_multiplier;
 pub mod streak;

--- a/src/commands/set_decay_rate.rs
+++ b/src/commands/set_decay_rate.rs
@@ -1,0 +1,29 @@
+use crate::{db::guilds::GuildRepo, Context, Error};
+
+/// Set the percent of points to remove from every user's score each day. 0 disables decay.
+#[poise::command(
+    prefix_command,
+    slash_command,
+    required_permissions = "ADMINISTRATOR",
+    guild_only
+)]
+pub async fn set_decay_rate(
+    ctx: Context<'_>,
+    #[description = "Percent per day (0-100). 0 disables decay."] pct: i64,
+) -> Result<(), Error> {
+    if !(0..=100).contains(&pct) {
+        ctx.say("decay rate must be between 0 and 100").await?;
+        return Ok(());
+    }
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let reply = match ctx.data().guilds.set_decay_rate(guild_id, pct as i32).await {
+        Ok(()) if pct == 0 => "score decay disabled".to_string(),
+        Ok(()) => format!("score decay set to {}%/day", pct),
+        Err(e) => {
+            eprintln!("[set_decay_rate] db error: {e}");
+            "failed to set decay rate".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}

--- a/src/db/guilds.rs
+++ b/src/db/guilds.rs
@@ -45,6 +45,7 @@ pub trait GuildRepo {
     async fn get_voice_multiplier(&self, guild_id: i64) -> i64;
     async fn set_text_multiplier(&self, guild_id: i64, multiplier: i64) -> Result<(), Error>;
     async fn get_text_multiplier(&self, guild_id: i64) -> i64;
+    async fn set_decay_rate(&self, guild_id: i64, pct: i32) -> Result<(), Error>;
     async fn guilds(&self) -> Result<Vec<Guild>, Error>;
 }
 
@@ -150,9 +151,28 @@ impl GuildRepo for Guilds {
             .unwrap_or(1)
     }
 
+    async fn set_decay_rate(&self, guild_id: i64, pct: i32) -> Result<(), Error> {
+        if !(0..=100).contains(&pct) {
+            return Err(Error::Protocol("decay rate must be between 0 and 100".into()));
+        }
+        sqlx::query!(
+            "INSERT INTO guilds (id, prefix, welcome_msg, voice_multiplier, text_multiplier, decay_per_day_pct) \
+             VALUES ($1, '!', '', 1, 1, $2) \
+             ON CONFLICT (id) DO UPDATE SET decay_per_day_pct = EXCLUDED.decay_per_day_pct",
+            guild_id,
+            pct,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
     async fn guilds(&self) -> Result<Vec<Guild>, Error> {
-        sqlx::query_as!(Guild, "SELECT * FROM guilds")
-            .fetch_all(&self.pool)
-            .await
+        sqlx::query_as!(
+            Guild,
+            "SELECT id, prefix, welcome_msg, voice_multiplier, text_multiplier FROM guilds"
+        )
+        .fetch_all(&self.pool)
+        .await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ async fn main() {
         | GatewayIntents::GUILD_MEMBERS;
 
     let http = Arc::new(Http::new(&token));
+    services::decay::spawn(pool.clone());
     let guilds = Guilds::new(&pool).await;
     let roles = Roles::new(&pool).await;
     let role_syncer = RoleSyncer::new(http.clone(), pool.clone(), roles.clone());
@@ -100,6 +101,7 @@ async fn main() {
                 commands::download_leaderboard::download_leaderboard(),
                 commands::role_thresholds::role_thresholds(),
                 commands::streak::streak(),
+                commands::set_decay_rate::set_decay_rate(),
             ],
             prefix_options: poise::PrefixFrameworkOptions {
                 dynamic_prefix: Some(|ctx| {

--- a/src/services/decay.rs
+++ b/src/services/decay.rs
@@ -1,0 +1,59 @@
+use sqlx::{Pool, Postgres};
+use tokio::time::{sleep, Duration};
+
+const TICK: Duration = Duration::from_secs(60 * 60); // hourly
+
+/// Spawn a background task that applies score decay for any guild whose
+/// `decay_per_day_pct` is greater than zero. Decay is compounded per day —
+/// missed days are caught up at the next tick.
+pub fn spawn(pool: Pool<Postgres>) {
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = run_once(&pool).await {
+                eprintln!("[decay] tick failed: {e}");
+            }
+            sleep(TICK).await;
+        }
+    });
+}
+
+async fn run_once(pool: &Pool<Postgres>) -> Result<(), sqlx::Error> {
+    let rows = sqlx::query!(
+        "SELECT id, decay_per_day_pct, last_decay_day FROM guilds \
+         WHERE decay_per_day_pct > 0"
+    )
+    .fetch_all(pool)
+    .await?;
+    let today = chrono::Utc::now().date_naive();
+    for row in rows {
+        let days = match row.last_decay_day {
+            Some(d) => (today - d).num_days() as i32,
+            None => 1,
+        };
+        if days <= 0 {
+            continue;
+        }
+        let pct = row.decay_per_day_pct;
+        sqlx::query!(
+            "UPDATE users \
+             SET score = GREATEST(0, FLOOR( \
+                 score::double precision * power(1.0 - $1::double precision / 100.0, $2::int) \
+             )::bigint) \
+             WHERE guild_id = $3",
+            pct as f64,
+            days,
+            row.id,
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query!(
+            "UPDATE guilds SET last_decay_day = $1 WHERE id = $2",
+            today,
+            row.id,
+        )
+        .execute(pool)
+        .await?;
+        tracing::info!(guild_id = row.id, pct, days, "applied score decay");
+    }
+    Ok(())
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,2 +1,3 @@
+pub mod decay;
 pub mod message;
 pub mod roles;


### PR DESCRIPTION
**Stacks on top of #43. Merge that first.**

## Summary
- Two new columns on `guilds`: `decay_per_day_pct` (0-100, default 0) and `last_decay_day`.
- Hourly background task (`services::decay::spawn`) iterates guilds with decay > 0 and applies compounded decay: `score := floor(score * (1 - pct/100)^days_passed)`. Catches up missed days.
- New admin command `/set_decay_rate <pct>` — 0 disables.

## Test plan
- [ ] Apply migration.
- [ ] Set decay to 50% and have a user with score 100; wait until the next tick or trigger a restart; confirm score becomes 50, then 25, etc.
- [ ] Set decay to 0; confirm no decay happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)