### PR TITLE
feat(multipliers): per-channel multiplier overrides

### DIFF
--- a/.sqlx/query-46df553f3a90ef842f92a7a136eca8d94fadd2bcb7f726a1754694d7eacd8d33.json
+++ b/.sqlx/query-46df553f3a90ef842f92a7a136eca8d94fadd2bcb7f726a1754694d7eacd8d33.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT text_multiplier FROM channel_multipliers WHERE guild_id = $1 AND channel_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "text_multiplier",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "46df553f3a90ef842f92a7a136eca8d94fadd2bcb7f726a1754694d7eacd8d33"
+}

--- a/.sqlx/query-70dc56eb75928d04d841d04094e136383ed9c8e034201ca81aa8980eed0370a1.json
+++ b/.sqlx/query-70dc56eb75928d04d841d04094e136383ed9c8e034201ca81aa8980eed0370a1.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO channel_multipliers (guild_id, channel_id, text_multiplier, voice_multiplier) VALUES ($1, $2, $3, $4) ON CONFLICT (guild_id, channel_id) DO UPDATE SET text_multiplier = COALESCE(EXCLUDED.text_multiplier, channel_multipliers.text_multiplier), voice_multiplier = COALESCE(EXCLUDED.voice_multiplier, channel_multipliers.voice_multiplier)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "70dc56eb75928d04d841d04094e136383ed9c8e034201ca81aa8980eed0370a1"
+}

--- a/.sqlx/query-80a0de4810dfe98f990f097a82c7d6474a476e915b57f2253e33aaa5b588936d.json
+++ b/.sqlx/query-80a0de4810dfe98f990f097a82c7d6474a476e915b57f2253e33aaa5b588936d.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT channel_id, text_multiplier, voice_multiplier FROM channel_multipliers WHERE guild_id = $1 ORDER BY channel_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "channel_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "text_multiplier",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "voice_multiplier",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "80a0de4810dfe98f990f097a82c7d6474a476e915b57f2253e33aaa5b588936d"
+}

--- a/.sqlx/query-8b3337922fb61c0b699a07de7128bf80c2c5f1d78f7a3978812961f0e3e6ea7c.json
+++ b/.sqlx/query-8b3337922fb61c0b699a07de7128bf80c2c5f1d78f7a3978812961f0e3e6ea7c.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT voice_multiplier FROM channel_multipliers WHERE guild_id = $1 AND channel_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "voice_multiplier",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "8b3337922fb61c0b699a07de7128bf80c2c5f1d78f7a3978812961f0e3e6ea7c"
+}

--- a/.sqlx/query-ef9ce7617a48fec14c54af02144d07b94c4426cecae4c7b099afc9811a6e97bf.json
+++ b/.sqlx/query-ef9ce7617a48fec14c54af02144d07b94c4426cecae4c7b099afc9811a6e97bf.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM channel_multipliers WHERE guild_id = $1 AND channel_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ef9ce7617a48fec14c54af02144d07b94c4426cecae4c7b099afc9811a6e97bf"
+}

--- a/migrations/20260629000005_channel_multipliers.sql
+++ b/migrations/20260629000005_channel_multipliers.sql
@@ -1,0 +1,7 @@
+CREATE TABLE channel_multipliers (
+    guild_id BIGINT NOT NULL,
+    channel_id BIGINT NOT NULL,
+    text_multiplier BIGINT,
+    voice_multiplier BIGINT,
+    PRIMARY KEY (guild_id, channel_id)
+);

--- a/src/commands/channel_multiplier.rs
+++ b/src/commands/channel_multiplier.rs
@@ -1,0 +1,114 @@
+use poise::CreateReply;
+use serenity::all::{Channel, CreateEmbed};
+
+use crate::{db::channels::ChannelsRepo, Context, Error};
+
+/// Per-channel overrides for text and voice scoring multipliers.
+#[poise::command(
+    prefix_command,
+    slash_command,
+    required_permissions = "ADMINISTRATOR",
+    guild_only,
+    subcommands("set", "clear", "list")
+)]
+pub async fn channel_multiplier(_ctx: Context<'_>) -> Result<(), Error> {
+    Ok(())
+}
+
+/// Override text and/or voice multiplier for a channel.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn set(
+    ctx: Context<'_>,
+    #[description = "Channel to override"] channel: Channel,
+    #[description = "Text multiplier (omit to leave unchanged)"] text: Option<i64>,
+    #[description = "Voice multiplier (omit to leave unchanged)"] voice: Option<i64>,
+) -> Result<(), Error> {
+    if text.is_none() && voice.is_none() {
+        ctx.say("provide at least one of `text:` or `voice:`").await?;
+        return Ok(());
+    }
+    if let Some(t) = text {
+        if t <= 0 {
+            ctx.say("text multiplier must be positive").await?;
+            return Ok(());
+        }
+    }
+    if let Some(v) = voice {
+        if v <= 0 {
+            ctx.say("voice multiplier must be positive").await?;
+            return Ok(());
+        }
+    }
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let channel_id = channel.id().get() as i64;
+    let reply = match ctx
+        .data()
+        .channels
+        .set_multiplier(guild_id, channel_id, text, voice)
+        .await
+    {
+        Ok(()) => format!(
+            "override set for <#{}>: text={:?} voice={:?}",
+            channel_id, text, voice
+        ),
+        Err(e) => {
+            eprintln!("[channel_multiplier set] db error: {e}");
+            "failed to set override".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}
+
+/// Remove the override for a channel (revert to guild default).
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn clear(
+    ctx: Context<'_>,
+    #[description = "Channel"] channel: Channel,
+) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let channel_id = channel.id().get() as i64;
+    let reply = match ctx.data().channels.clear_multiplier(guild_id, channel_id).await {
+        Ok(()) => format!("override cleared for <#{}>", channel_id),
+        Err(e) => {
+            eprintln!("[channel_multiplier clear] db error: {e}");
+            "failed to clear override".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}
+
+/// List channel-level overrides for this guild.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn list(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let rows = match ctx.data().channels.list(guild_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("[channel_multiplier list] db error: {e}");
+            ctx.say("failed to list overrides").await?;
+            return Ok(());
+        }
+    };
+    let body = if rows.is_empty() {
+        "(none configured)".to_string()
+    } else {
+        rows.into_iter()
+            .map(|r| {
+                format!(
+                    "- <#{}> text={} voice={}\n",
+                    r.channel_id,
+                    r.text_multiplier.map(|v| v.to_string()).unwrap_or_else(|| "—".to_string()),
+                    r.voice_multiplier.map(|v| v.to_string()).unwrap_or_else(|| "—".to_string()),
+                )
+            })
+            .collect()
+    };
+    let embed = CreateEmbed::new()
+        .title("channel multipliers")
+        .description(body)
+        .colour((58, 8, 9));
+    ctx.send(CreateReply::default().embed(embed).reply(true)).await?;
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod channel_multiplier;
 pub mod download_leaderboard;
 pub mod get_prefix;
 pub mod help;

--- a/src/db/channels.rs
+++ b/src/db/channels.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use sqlx::{Error, Pool, Postgres};
+
+pub struct Channels {
+    pub pool: Pool<Postgres>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ChannelMultiplier {
+    pub channel_id: i64,
+    pub text_multiplier: Option<i64>,
+    pub voice_multiplier: Option<i64>,
+}
+
+#[async_trait]
+pub trait ChannelsRepo {
+    async fn new(pool: &Pool<Postgres>) -> Arc<Self>;
+    async fn set_multiplier(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        text: Option<i64>,
+        voice: Option<i64>,
+    ) -> Result<(), Error>;
+    async fn clear_multiplier(&self, guild_id: i64, channel_id: i64) -> Result<(), Error>;
+    async fn list(&self, guild_id: i64) -> Result<Vec<ChannelMultiplier>, Error>;
+    async fn get_text(&self, guild_id: i64, channel_id: i64) -> Option<i64>;
+    async fn get_voice(&self, guild_id: i64, channel_id: i64) -> Option<i64>;
+}
+
+#[async_trait]
+impl ChannelsRepo for Channels {
+    async fn new(pool: &Pool<Postgres>) -> Arc<Self> {
+        Arc::new(Channels { pool: pool.clone() })
+    }
+
+    async fn set_multiplier(
+        &self,
+        guild_id: i64,
+        channel_id: i64,
+        text: Option<i64>,
+        voice: Option<i64>,
+    ) -> Result<(), Error> {
+        // COALESCE preserves the existing column when the caller passes None
+        // for one side and Some for the other.
+        sqlx::query!(
+            "INSERT INTO channel_multipliers (guild_id, channel_id, text_multiplier, voice_multiplier) \
+             VALUES ($1, $2, $3, $4) \
+             ON CONFLICT (guild_id, channel_id) DO UPDATE SET \
+                 text_multiplier = COALESCE(EXCLUDED.text_multiplier, channel_multipliers.text_multiplier), \
+                 voice_multiplier = COALESCE(EXCLUDED.voice_multiplier, channel_multipliers.voice_multiplier)",
+            guild_id,
+            channel_id,
+            text,
+            voice,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn clear_multiplier(&self, guild_id: i64, channel_id: i64) -> Result<(), Error> {
+        sqlx::query!(
+            "DELETE FROM channel_multipliers WHERE guild_id = $1 AND channel_id = $2",
+            guild_id,
+            channel_id,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn list(&self, guild_id: i64) -> Result<Vec<ChannelMultiplier>, Error> {
+        let rows = sqlx::query!(
+            "SELECT channel_id, text_multiplier, voice_multiplier \
+             FROM channel_multipliers WHERE guild_id = $1 \
+             ORDER BY channel_id",
+            guild_id,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows
+            .into_iter()
+            .map(|r| ChannelMultiplier {
+                channel_id: r.channel_id,
+                text_multiplier: r.text_multiplier,
+                voice_multiplier: r.voice_multiplier,
+            })
+            .collect())
+    }
+
+    async fn get_text(&self, guild_id: i64, channel_id: i64) -> Option<i64> {
+        sqlx::query_scalar!(
+            "SELECT text_multiplier FROM channel_multipliers \
+             WHERE guild_id = $1 AND channel_id = $2",
+            guild_id,
+            channel_id,
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+        .flatten()
+    }
+
+    async fn get_voice(&self, guild_id: i64, channel_id: i64) -> Option<i64> {
+        sqlx::query_scalar!(
+            "SELECT voice_multiplier FROM channel_multipliers \
+             WHERE guild_id = $1 AND channel_id = $2",
+            guild_id,
+            channel_id,
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+        .flatten()
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,4 @@
+pub mod channels;
 pub mod events;
 pub mod guilds;
 pub mod roles;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use db::{
+    channels::{Channels, ChannelsRepo},
     guilds::{GuildRepo, Guilds},
     roles::{Roles, RolesRepo},
     users::{Users, UsersRepo},
@@ -29,6 +30,7 @@ pub struct Data {
     pub guilds: Arc<Guilds>,
     pub users: Arc<Users>,
     pub roles: Arc<Roles>,
+    pub channels: Arc<Channels>,
     pub active_users: Arc<Mutex<HashSet<(i64, i64)>>>,
 }
 
@@ -82,6 +84,7 @@ async fn main() {
     services::decay::spawn(pool.clone());
     let guilds = Guilds::new(&pool).await;
     let roles = Roles::new(&pool).await;
+    let channels = Channels::new(&pool).await;
     let role_syncer = RoleSyncer::new(http.clone(), pool.clone(), roles.clone());
     let users = Users::new(&pool, role_syncer).await;
     let active_users = Arc::new(Mutex::new(HashSet::new()));
@@ -102,6 +105,7 @@ async fn main() {
                 commands::role_thresholds::role_thresholds(),
                 commands::streak::streak(),
                 commands::set_decay_rate::set_decay_rate(),
+                commands::channel_multiplier::channel_multiplier(),
             ],
             prefix_options: poise::PrefixFrameworkOptions {
                 dynamic_prefix: Some(|ctx| {
@@ -126,6 +130,7 @@ async fn main() {
                     guilds,
                     users,
                     roles,
+                    channels,
                     active_users,
                 })
             })
@@ -162,6 +167,7 @@ async fn event_handler(
                 new_message.author.name.clone(),
                 new_message.author.bot,
                 guild_id.get() as i64,
+                new_message.channel_id.get() as i64,
             )
             .await;
         }

--- a/src/services/message.rs
+++ b/src/services/message.rs
@@ -1,6 +1,9 @@
 use serenity::all::{ChannelId, Context, GuildId, Member, UserId, VoiceState};
 
-use crate::{db::guilds::GuildRepo, Data};
+use crate::{
+    db::{channels::ChannelsRepo, guilds::GuildRepo},
+    Data,
+};
 
 pub async fn increase_score(
     data: &Data,
@@ -8,8 +11,12 @@ pub async fn increase_score(
     nick: String,
     is_bot: bool,
     guild_id: i64,
+    channel_id: i64,
 ) {
-    let multiplier = data.guilds.get_text_multiplier(guild_id).await;
+    let multiplier = match data.channels.get_text(guild_id, channel_id).await {
+        Some(m) => m,
+        None => data.guilds.get_text_multiplier(guild_id).await,
+    };
     if let Err(e) = data.users.tx.send(crate::db::events::UserEvents::SentText(
         user_id, nick, is_bot, guild_id, multiplier,
     )) {
@@ -51,7 +58,11 @@ pub async fn handle_voice(ctx: Context, data: &Data, voice: VoiceState) {
                 .map(|m| m.display_name().to_string())
                 .unwrap_or_else(|| voice.user_id.get().to_string()),
         };
-        let multiplier = data.guilds.get_voice_multiplier(guild_id_i64).await;
+        let voice_channel_id = voice.channel_id.unwrap().get() as i64;
+        let multiplier = match data.channels.get_voice(guild_id_i64, voice_channel_id).await {
+            Some(m) => m,
+            None => data.guilds.get_voice_multiplier(guild_id_i64).await,
+        };
 
         active_users.insert(key);
         drop(active_users);
@@ -78,6 +89,7 @@ pub struct VoiceStateReady {
 pub async fn init_active_users(_ctx: Context, data: &Data, voice: VoiceStateReady) {
     let guild_id_i64 = voice.guild_id.get() as i64;
     let user_id = voice.user_id.get() as i64;
+    let channel_id = voice._channel_id.get() as i64;
     let key = (guild_id_i64, user_id);
 
     let mut active_users = data.active_users.lock().await;
@@ -87,7 +99,10 @@ pub async fn init_active_users(_ctx: Context, data: &Data, voice: VoiceStateRead
     active_users.insert(key);
     drop(active_users);
 
-    let multiplier = data.guilds.get_voice_multiplier(guild_id_i64).await;
+    let multiplier = match data.channels.get_voice(guild_id_i64, channel_id).await {
+        Some(m) => m,
+        None => data.guilds.get_voice_multiplier(guild_id_i64).await,
+    };
     let nick = voice
         .member
         .nick


### PR DESCRIPTION
**Stacks on top of #44. Merge that first.**

## Summary
- New `channel_multipliers (guild_id, channel_id, text_multiplier?, voice_multiplier?)` — both columns independently nullable.
- Text scoring: `services::message::increase_score` now takes a `channel_id` and consults the override before falling back to the guild default.
- Voice scoring: the multiplier is captured at join time (same as before) but now reads the channel override first.
- New `/channel_multiplier set|clear|list` admin subcommand group.

## Test plan
- [ ] Apply migration.
- [ ] Set a 10× text override on #activity and confirm messages there award 10 points each.
- [ ] Set a voice override on a VC, join, wait for a tick, confirm the per-tick increment matches.
- [ ] Clear the override and confirm the guild default applies again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)