### PR TITLE
feat(stats): /user_stats command

### DIFF
--- a/.sqlx/query-ca3d3a6a9d71850621cf2466cd0f7511a0cf6aa0cfba15eaa26233adebba140b.json
+++ b/.sqlx/query-ca3d3a6a9d71850621cf2466cd0f7511a0cf6aa0cfba15eaa26233adebba140b.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH ranked AS ( SELECT id, score, ROW_NUMBER() OVER (ORDER BY score DESC, id ASC) AS rnk FROM users WHERE guild_id = $1 AND is_bot = false ), events AS ( SELECT MAX(occurred_at) AS last_active, COUNT(*) AS event_count FROM score_events WHERE guild_id = $1 AND user_id = $2 ) SELECT r.score, r.rnk AS \"rnk!\", (SELECT last_active FROM events) AS last_active, (SELECT event_count FROM events) AS event_count FROM ranked r WHERE r.id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "score",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "rnk!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_active",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "event_count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "ca3d3a6a9d71850621cf2466cd0f7511a0cf6aa0cfba15eaa26233adebba140b"
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,5 +10,6 @@ pub mod set_decay_rate;
 pub mod set_prefix;
 pub mod set_text_multiplier;
 pub mod streak;
+pub mod user_stats;
 pub mod set_voice_multiplier;
 pub mod set_welcome_msg;

--- a/src/commands/user_stats.rs
+++ b/src/commands/user_stats.rs
@@ -1,0 +1,51 @@
+use poise::CreateReply;
+use serenity::all::{CreateEmbed, User};
+
+use crate::{db::users::UsersRepo, Context, Error};
+
+/// Show a user's score, rank, streak, and most recent activity.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn user_stats(
+    ctx: Context<'_>,
+    #[description = "User to inspect (defaults to you)"] user: Option<User>,
+) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let target = user.unwrap_or_else(|| ctx.author().clone());
+    let target_id = target.id.get() as i64;
+
+    let stats = match ctx.data().users.get_user_stats(target_id, guild_id).await {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            ctx.say(format!("{} has no activity recorded yet.", target.name))
+                .await?;
+            return Ok(());
+        }
+        Err(e) => {
+            eprintln!("[user_stats] db error: {e}");
+            ctx.say("failed to read stats").await?;
+            return Ok(());
+        }
+    };
+    let streak = ctx
+        .data()
+        .users
+        .get_streak(target_id, guild_id)
+        .await
+        .unwrap_or(0);
+
+    let last_active = stats
+        .last_active
+        .map(|t| t.format("%Y-%m-%d %H:%M UTC").to_string())
+        .unwrap_or_else(|| "—".to_string());
+
+    let body = format!(
+        "score: {}\nrank: #{}\nstreak: {} days\nscoring events: {}\nlast scored: {}",
+        stats.score, stats.rank, streak, stats.event_count, last_active,
+    );
+    let embed = CreateEmbed::new()
+        .title(format!("stats — {}", target.name))
+        .description(body)
+        .colour((58, 8, 9));
+    ctx.send(CreateReply::default().embed(embed).reply(true)).await?;
+    Ok(())
+}

--- a/src/db/users.rs
+++ b/src/db/users.rs
@@ -50,6 +50,19 @@ pub trait UsersRepo {
     ) -> Result<Vec<User>, Error>;
     async fn reset_scores(&self, guild_id: i64) -> Result<(), Error>;
     async fn get_streak(&self, user_id: i64, guild_id: i64) -> Result<i64, Error>;
+    async fn get_user_stats(
+        &self,
+        user_id: i64,
+        guild_id: i64,
+    ) -> Result<Option<UserStats>, Error>;
+}
+
+#[derive(Debug)]
+pub struct UserStats {
+    pub score: i64,
+    pub rank: i64,
+    pub last_active: Option<chrono::DateTime<chrono::Utc>>,
+    pub event_count: i64,
 }
 
 #[async_trait]
@@ -194,6 +207,40 @@ impl UsersRepo for Users {
             .execute(&self.pool)
             .await
             .map(|_| ())
+    }
+
+    async fn get_user_stats(
+        &self,
+        user_id: i64,
+        guild_id: i64,
+    ) -> Result<Option<UserStats>, Error> {
+        let row = sqlx::query!(
+            "WITH ranked AS ( \
+               SELECT id, score, \
+                      ROW_NUMBER() OVER (ORDER BY score DESC, id ASC) AS rnk \
+               FROM users \
+               WHERE guild_id = $1 AND is_bot = false \
+             ), \
+             events AS ( \
+               SELECT MAX(occurred_at) AS last_active, COUNT(*) AS event_count \
+               FROM score_events WHERE guild_id = $1 AND user_id = $2 \
+             ) \
+             SELECT r.score, r.rnk AS \"rnk!\", \
+                    (SELECT last_active FROM events) AS last_active, \
+                    (SELECT event_count FROM events) AS event_count \
+             FROM ranked r \
+             WHERE r.id = $2",
+            guild_id,
+            user_id,
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|r| UserStats {
+            score: r.score,
+            rank: r.rnk,
+            last_active: r.last_active,
+            event_count: r.event_count.unwrap_or(0),
+        }))
     }
 
     async fn get_streak(&self, user_id: i64, guild_id: i64) -> Result<i64, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,7 @@ async fn main() {
                 commands::streak::streak(),
                 commands::set_decay_rate::set_decay_rate(),
                 commands::channel_multiplier::channel_multiplier(),
+                commands::user_stats::user_stats(),
             ],
             prefix_options: poise::PrefixFrameworkOptions {
                 dynamic_prefix: Some(|ctx| {


### PR DESCRIPTION
**Stacks on top of #45. Merge that first.**

## Summary
- `Users::get_user_stats(user_id, guild_id) -> Option<UserStats>` — single query, ROW_NUMBER ranks within the guild, joins MAX(occurred_at) and COUNT(*) from score_events.
- New `/user_stats [@user]` command (defaults to caller); shows score, rank, streak, total scoring events, last activity timestamp.

## Test plan
- [ ] Run `/user_stats` and confirm rank matches your position on `/leaderboard`.
- [ ] Run `/user_stats @someone` and confirm it works against another user.
- [ ] Confirm the response shows "no activity" cleanly for never-seen users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)