### PR TITLE
feat(channels): excluded channels skip scoring

### DIFF
--- a/.sqlx/query-7776a279ca964210b34038b65541d14083d3c006d798381cca9b698b0d081b66.json
+++ b/.sqlx/query-7776a279ca964210b34038b65541d14083d3c006d798381cca9b698b0d081b66.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT channel_id FROM excluded_channels WHERE guild_id = $1 ORDER BY channel_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "channel_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "7776a279ca964210b34038b65541d14083d3c006d798381cca9b698b0d081b66"
+}

--- a/.sqlx/query-826f579ddea2934082244265617a4043f18a30fde7ab246b1814635a0a8d7660.json
+++ b/.sqlx/query-826f579ddea2934082244265617a4043f18a30fde7ab246b1814635a0a8d7660.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO excluded_channels (guild_id, channel_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "826f579ddea2934082244265617a4043f18a30fde7ab246b1814635a0a8d7660"
+}

--- a/.sqlx/query-eb8d75431f4bf2f1db07fe5bc932f2d28b0e3bdd81d6a01fde0b6f78381e2a81.json
+++ b/.sqlx/query-eb8d75431f4bf2f1db07fe5bc932f2d28b0e3bdd81d6a01fde0b6f78381e2a81.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM excluded_channels WHERE guild_id = $1 AND channel_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "eb8d75431f4bf2f1db07fe5bc932f2d28b0e3bdd81d6a01fde0b6f78381e2a81"
+}

--- a/.sqlx/query-f7b95adc75efec6f734d0eb8a877743f6cd32540f0f0e29c9a91dc7865b14bb2.json
+++ b/.sqlx/query-f7b95adc75efec6f734d0eb8a877743f6cd32540f0f0e29c9a91dc7865b14bb2.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM excluded_channels WHERE guild_id = $1 AND channel_id = $2)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "f7b95adc75efec6f734d0eb8a877743f6cd32540f0f0e29c9a91dc7865b14bb2"
+}

--- a/migrations/20260629000006_excluded_channels.sql
+++ b/migrations/20260629000006_excluded_channels.sql
@@ -1,0 +1,5 @@
+CREATE TABLE excluded_channels (
+    guild_id BIGINT NOT NULL,
+    channel_id BIGINT NOT NULL,
+    PRIMARY KEY (guild_id, channel_id)
+);

--- a/src/commands/excluded_channels.rs
+++ b/src/commands/excluded_channels.rs
@@ -1,0 +1,79 @@
+use poise::CreateReply;
+use serenity::all::{Channel, CreateEmbed};
+
+use crate::{db::channels::ChannelsRepo, Context, Error};
+
+/// Manage channels where activity does NOT award points.
+#[poise::command(
+    prefix_command,
+    slash_command,
+    required_permissions = "ADMINISTRATOR",
+    guild_only,
+    subcommands("add", "remove", "list")
+)]
+pub async fn excluded_channels(_ctx: Context<'_>) -> Result<(), Error> {
+    Ok(())
+}
+
+/// Stop awarding points for activity in this channel.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn add(
+    ctx: Context<'_>,
+    #[description = "Channel to exclude"] channel: Channel,
+) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let channel_id = channel.id().get() as i64;
+    let reply = match ctx.data().channels.exclude(guild_id, channel_id).await {
+        Ok(()) => format!("excluded <#{}> from scoring", channel_id),
+        Err(e) => {
+            eprintln!("[excluded_channels add] db error: {e}");
+            "failed to exclude channel".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}
+
+/// Re-enable scoring for this channel.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn remove(
+    ctx: Context<'_>,
+    #[description = "Channel"] channel: Channel,
+) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let channel_id = channel.id().get() as i64;
+    let reply = match ctx.data().channels.include(guild_id, channel_id).await {
+        Ok(()) => format!("re-enabled scoring for <#{}>", channel_id),
+        Err(e) => {
+            eprintln!("[excluded_channels remove] db error: {e}");
+            "failed to re-enable scoring".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}
+
+/// List excluded channels.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn list(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let ids = match ctx.data().channels.list_excluded(guild_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("[excluded_channels list] db error: {e}");
+            ctx.say("failed to list").await?;
+            return Ok(());
+        }
+    };
+    let body = if ids.is_empty() {
+        "(none)".to_string()
+    } else {
+        ids.into_iter().map(|id| format!("- <#{}>\n", id)).collect()
+    };
+    let embed = CreateEmbed::new()
+        .title("excluded channels")
+        .description(body)
+        .colour((58, 8, 9));
+    ctx.send(CreateReply::default().embed(embed).reply(true)).await?;
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod channel_multiplier;
 pub mod download_leaderboard;
+pub mod excluded_channels;
 pub mod get_prefix;
 pub mod help;
 pub mod leaderboard;

--- a/src/db/channels.rs
+++ b/src/db/channels.rs
@@ -28,6 +28,10 @@ pub trait ChannelsRepo {
     async fn list(&self, guild_id: i64) -> Result<Vec<ChannelMultiplier>, Error>;
     async fn get_text(&self, guild_id: i64, channel_id: i64) -> Option<i64>;
     async fn get_voice(&self, guild_id: i64, channel_id: i64) -> Option<i64>;
+    async fn exclude(&self, guild_id: i64, channel_id: i64) -> Result<(), Error>;
+    async fn include(&self, guild_id: i64, channel_id: i64) -> Result<(), Error>;
+    async fn is_excluded(&self, guild_id: i64, channel_id: i64) -> bool;
+    async fn list_excluded(&self, guild_id: i64) -> Result<Vec<i64>, Error>;
 }
 
 #[async_trait]
@@ -117,5 +121,51 @@ impl ChannelsRepo for Channels {
         .ok()
         .flatten()
         .flatten()
+    }
+
+    async fn exclude(&self, guild_id: i64, channel_id: i64) -> Result<(), Error> {
+        sqlx::query!(
+            "INSERT INTO excluded_channels (guild_id, channel_id) VALUES ($1, $2) \
+             ON CONFLICT DO NOTHING",
+            guild_id,
+            channel_id,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn include(&self, guild_id: i64, channel_id: i64) -> Result<(), Error> {
+        sqlx::query!(
+            "DELETE FROM excluded_channels WHERE guild_id = $1 AND channel_id = $2",
+            guild_id,
+            channel_id,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn is_excluded(&self, guild_id: i64, channel_id: i64) -> bool {
+        sqlx::query_scalar!(
+            "SELECT EXISTS(SELECT 1 FROM excluded_channels \
+             WHERE guild_id = $1 AND channel_id = $2)",
+            guild_id,
+            channel_id,
+        )
+        .fetch_one(&self.pool)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or(false)
+    }
+
+    async fn list_excluded(&self, guild_id: i64) -> Result<Vec<i64>, Error> {
+        sqlx::query_scalar!(
+            "SELECT channel_id FROM excluded_channels WHERE guild_id = $1 ORDER BY channel_id",
+            guild_id,
+        )
+        .fetch_all(&self.pool)
+        .await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ async fn main() {
                 commands::set_decay_rate::set_decay_rate(),
                 commands::channel_multiplier::channel_multiplier(),
                 commands::user_stats::user_stats(),
+                commands::excluded_channels::excluded_channels(),
             ],
             prefix_options: poise::PrefixFrameworkOptions {
                 dynamic_prefix: Some(|ctx| {

--- a/src/services/message.rs
+++ b/src/services/message.rs
@@ -13,6 +13,9 @@ pub async fn increase_score(
     guild_id: i64,
     channel_id: i64,
 ) {
+    if data.channels.is_excluded(guild_id, channel_id).await {
+        return;
+    }
     let multiplier = match data.channels.get_text(guild_id, channel_id).await {
         Some(m) => m,
         None => data.guilds.get_text_multiplier(guild_id).await,
@@ -46,6 +49,10 @@ pub async fn handle_voice(ctx: Context, data: &Data, voice: VoiceState) {
             eprintln!("[handle_voice/Left] event channel closed: {e}");
         }
     } else if !is_active && voice.channel_id.is_some() {
+        let voice_channel_id = voice.channel_id.unwrap().get() as i64;
+        if data.channels.is_excluded(guild_id_i64, voice_channel_id).await {
+            return;
+        }
         let is_bot = voice.member.as_ref().map(|m| m.user.bot).unwrap_or(false);
         let nick = match guild_id.member(&ctx.http, voice.user_id).await {
             Ok(m) => m
@@ -58,7 +65,6 @@ pub async fn handle_voice(ctx: Context, data: &Data, voice: VoiceState) {
                 .map(|m| m.display_name().to_string())
                 .unwrap_or_else(|| voice.user_id.get().to_string()),
         };
-        let voice_channel_id = voice.channel_id.unwrap().get() as i64;
         let multiplier = match data.channels.get_voice(guild_id_i64, voice_channel_id).await {
             Some(m) => m,
             None => data.guilds.get_voice_multiplier(guild_id_i64).await,
@@ -90,6 +96,9 @@ pub async fn init_active_users(_ctx: Context, data: &Data, voice: VoiceStateRead
     let guild_id_i64 = voice.guild_id.get() as i64;
     let user_id = voice.user_id.get() as i64;
     let channel_id = voice._channel_id.get() as i64;
+    if data.channels.is_excluded(guild_id_i64, channel_id).await {
+        return;
+    }
     let key = (guild_id_i64, user_id);
 
     let mut active_users = data.active_users.lock().await;


### PR DESCRIPTION
**Stacks on top of #46.**

## Summary
- New `excluded_channels(guild_id, channel_id)` table.
- `Channels` repo gets `exclude/include/is_excluded/list_excluded`.
- Text path (`increase_score`) early-returns if the channel is excluded.
- Voice path (`handle_voice` + `init_active_users`) early-returns before inserting into `active_users`, so the per-user ticker never starts for an excluded VC.
- `/excluded_channels add|remove|list` admin subcommand group.

## Test plan
- [ ] Exclude #bot-spam; confirm messages there don't move the leaderboard.
- [ ] Exclude an AFK VC; join it; confirm no points accrue.
- [ ] `remove` and confirm scoring resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)