### PR TITLE
feat(anti-spam): min length + per-user cooldown

### DIFF
--- a/.sqlx/query-16183204548aaf1737a25bbb135166581bcd644aa950866c72decdc7a4d4b466.json
+++ b/.sqlx/query-16183204548aaf1737a25bbb135166581bcd644aa950866c72decdc7a4d4b466.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT min_msg_length, msg_cooldown_secs FROM guilds WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "min_msg_length",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "msg_cooldown_secs",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "16183204548aaf1737a25bbb135166581bcd644aa950866c72decdc7a4d4b466"
+}

--- a/.sqlx/query-90e6625a86fec33c8c4bb6c458e322e967d7cd67cdb5ec0a41b4b0cb94c23463.json
+++ b/.sqlx/query-90e6625a86fec33c8c4bb6c458e322e967d7cd67cdb5ec0a41b4b0cb94c23463.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO guilds (id, prefix, welcome_msg, voice_multiplier, text_multiplier, msg_cooldown_secs) VALUES ($1, '!', '', 1, 1, $2) ON CONFLICT (id) DO UPDATE SET msg_cooldown_secs = EXCLUDED.msg_cooldown_secs",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "90e6625a86fec33c8c4bb6c458e322e967d7cd67cdb5ec0a41b4b0cb94c23463"
+}

--- a/.sqlx/query-f887c6085c233a03322c3e5c700621b8671e3d314e9b9f77039472afe5bdb431.json
+++ b/.sqlx/query-f887c6085c233a03322c3e5c700621b8671e3d314e9b9f77039472afe5bdb431.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO guilds (id, prefix, welcome_msg, voice_multiplier, text_multiplier, min_msg_length) VALUES ($1, '!', '', 1, 1, $2) ON CONFLICT (id) DO UPDATE SET min_msg_length = EXCLUDED.min_msg_length",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f887c6085c233a03322c3e5c700621b8671e3d314e9b9f77039472afe5bdb431"
+}

--- a/migrations/20260629000007_anti_spam.sql
+++ b/migrations/20260629000007_anti_spam.sql
@@ -1,0 +1,3 @@
+ALTER TABLE guilds
+    ADD COLUMN min_msg_length INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN msg_cooldown_secs INTEGER NOT NULL DEFAULT 0;

--- a/src/commands/anti_spam.rs
+++ b/src/commands/anti_spam.rs
@@ -1,0 +1,67 @@
+use crate::{db::guilds::GuildRepo, Context, Error};
+
+/// Ignore messages shorter than this many characters when scoring.
+#[poise::command(
+    prefix_command,
+    slash_command,
+    required_permissions = "ADMINISTRATOR",
+    guild_only
+)]
+pub async fn set_min_msg_length(
+    ctx: Context<'_>,
+    #[description = "Minimum characters (0 disables)"] chars: i64,
+) -> Result<(), Error> {
+    if chars < 0 {
+        ctx.say("min length cannot be negative").await?;
+        return Ok(());
+    }
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let reply = match ctx
+        .data()
+        .guilds
+        .set_min_msg_length(guild_id, chars as i32)
+        .await
+    {
+        Ok(()) if chars == 0 => "min message length disabled".to_string(),
+        Ok(()) => format!("messages shorter than {} chars won't score", chars),
+        Err(e) => {
+            eprintln!("[set_min_msg_length] db error: {e}");
+            "failed to set min length".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}
+
+/// Require N seconds between scoring messages from the same user.
+#[poise::command(
+    prefix_command,
+    slash_command,
+    required_permissions = "ADMINISTRATOR",
+    guild_only
+)]
+pub async fn set_msg_cooldown(
+    ctx: Context<'_>,
+    #[description = "Cooldown in seconds (0 disables)"] secs: i64,
+) -> Result<(), Error> {
+    if secs < 0 {
+        ctx.say("cooldown cannot be negative").await?;
+        return Ok(());
+    }
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let reply = match ctx
+        .data()
+        .guilds
+        .set_msg_cooldown(guild_id, secs as i32)
+        .await
+    {
+        Ok(()) if secs == 0 => "message cooldown disabled".to_string(),
+        Ok(()) => format!("cooldown set to {}s between scoring messages", secs),
+        Err(e) => {
+            eprintln!("[set_msg_cooldown] db error: {e}");
+            "failed to set cooldown".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod anti_spam;
 pub mod channel_multiplier;
 pub mod download_leaderboard;
 pub mod excluded_channels;

--- a/src/db/guilds.rs
+++ b/src/db/guilds.rs
@@ -22,6 +22,12 @@ pub struct Guild {
     text_multiplier: i64,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AntiSpamSettings {
+    pub min_msg_length: i32,
+    pub cooldown_secs: i32,
+}
+
 impl Default for Guild {
     fn default() -> Self {
         Self {
@@ -46,6 +52,9 @@ pub trait GuildRepo {
     async fn set_text_multiplier(&self, guild_id: i64, multiplier: i64) -> Result<(), Error>;
     async fn get_text_multiplier(&self, guild_id: i64) -> i64;
     async fn set_decay_rate(&self, guild_id: i64, pct: i32) -> Result<(), Error>;
+    async fn set_min_msg_length(&self, guild_id: i64, len: i32) -> Result<(), Error>;
+    async fn set_msg_cooldown(&self, guild_id: i64, secs: i32) -> Result<(), Error>;
+    async fn get_anti_spam(&self, guild_id: i64) -> AntiSpamSettings;
     async fn guilds(&self) -> Result<Vec<Guild>, Error>;
 }
 
@@ -165,6 +174,54 @@ impl GuildRepo for Guilds {
         .execute(&self.pool)
         .await
         .map(|_| ())
+    }
+
+    async fn set_min_msg_length(&self, guild_id: i64, len: i32) -> Result<(), Error> {
+        if len < 0 {
+            return Err(Error::Protocol("min_msg_length cannot be negative".into()));
+        }
+        sqlx::query!(
+            "INSERT INTO guilds (id, prefix, welcome_msg, voice_multiplier, text_multiplier, min_msg_length) \
+             VALUES ($1, '!', '', 1, 1, $2) \
+             ON CONFLICT (id) DO UPDATE SET min_msg_length = EXCLUDED.min_msg_length",
+            guild_id,
+            len,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn set_msg_cooldown(&self, guild_id: i64, secs: i32) -> Result<(), Error> {
+        if secs < 0 {
+            return Err(Error::Protocol("cooldown cannot be negative".into()));
+        }
+        sqlx::query!(
+            "INSERT INTO guilds (id, prefix, welcome_msg, voice_multiplier, text_multiplier, msg_cooldown_secs) \
+             VALUES ($1, '!', '', 1, 1, $2) \
+             ON CONFLICT (id) DO UPDATE SET msg_cooldown_secs = EXCLUDED.msg_cooldown_secs",
+            guild_id,
+            secs,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn get_anti_spam(&self, guild_id: i64) -> AntiSpamSettings {
+        match sqlx::query!(
+            "SELECT min_msg_length, msg_cooldown_secs FROM guilds WHERE id = $1",
+            guild_id
+        )
+        .fetch_optional(&self.pool)
+        .await
+        {
+            Ok(Some(r)) => AntiSpamSettings {
+                min_msg_length: r.min_msg_length,
+                cooldown_secs: r.msg_cooldown_secs,
+            },
+            _ => AntiSpamSettings::default(),
+        }
     }
 
     async fn guilds(&self) -> Result<Vec<Guild>, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     env,
     sync::Arc,
+    time::Instant,
 };
 
 use db::{
@@ -32,6 +33,8 @@ pub struct Data {
     pub roles: Arc<Roles>,
     pub channels: Arc<Channels>,
     pub active_users: Arc<Mutex<HashSet<(i64, i64)>>>,
+    /// (user_id, guild_id) -> last accepted message time. Anti-spam cooldown.
+    pub last_msg_at: Arc<Mutex<HashMap<(i64, i64), Instant>>>,
 }
 
 #[tokio::main]
@@ -88,6 +91,7 @@ async fn main() {
     let role_syncer = RoleSyncer::new(http.clone(), pool.clone(), roles.clone());
     let users = Users::new(&pool, role_syncer).await;
     let active_users = Arc::new(Mutex::new(HashSet::new()));
+    let last_msg_at = Arc::new(Mutex::new(HashMap::new()));
 
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
@@ -108,6 +112,8 @@ async fn main() {
                 commands::channel_multiplier::channel_multiplier(),
                 commands::user_stats::user_stats(),
                 commands::excluded_channels::excluded_channels(),
+                commands::anti_spam::set_min_msg_length(),
+                commands::anti_spam::set_msg_cooldown(),
             ],
             prefix_options: poise::PrefixFrameworkOptions {
                 dynamic_prefix: Some(|ctx| {
@@ -134,6 +140,7 @@ async fn main() {
                     roles,
                     channels,
                     active_users,
+                    last_msg_at,
                 })
             })
         })
@@ -170,6 +177,7 @@ async fn event_handler(
                 new_message.author.bot,
                 guild_id.get() as i64,
                 new_message.channel_id.get() as i64,
+                new_message.content.chars().count(),
             )
             .await;
         }

--- a/src/services/message.rs
+++ b/src/services/message.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use serenity::all::{ChannelId, Context, GuildId, Member, UserId, VoiceState};
 
 use crate::{
@@ -12,9 +14,25 @@ pub async fn increase_score(
     is_bot: bool,
     guild_id: i64,
     channel_id: i64,
+    msg_length: usize,
 ) {
     if data.channels.is_excluded(guild_id, channel_id).await {
         return;
+    }
+    let anti_spam = data.guilds.get_anti_spam(guild_id).await;
+    if msg_length < anti_spam.min_msg_length as usize {
+        return;
+    }
+    if anti_spam.cooldown_secs > 0 {
+        let now = Instant::now();
+        let cooldown = Duration::from_secs(anti_spam.cooldown_secs as u64);
+        let mut map = data.last_msg_at.lock().await;
+        if let Some(last) = map.get(&(user_id, guild_id)) {
+            if now.duration_since(*last) < cooldown {
+                return;
+            }
+        }
+        map.insert((user_id, guild_id), now);
     }
     let multiplier = match data.channels.get_text(guild_id, channel_id).await {
         Some(m) => m,


### PR DESCRIPTION
**Stacks on top of #47.**

## Summary
- Two new `guilds` columns: `min_msg_length`, `msg_cooldown_secs` (both default 0).
- `Data.last_msg_at: Arc<Mutex<HashMap<(user,guild), Instant>>>` tracks last accepted message; the text path early-returns if the message is shorter than the min OR within the cooldown.
- New `/set_min_msg_length <chars>` and `/set_msg_cooldown <secs>` admin commands. 0 disables either.
- `increase_score` now takes a `msg_length` arg fed by `new_message.content.chars().count()`.

## Notes
- The cooldown map is in-memory, so a restart resets the cooldowns. That's fine for the intent (block short bursts) and avoids per-message DB writes.
- Anti-spam fires *before* the channel-multiplier lookup so we save DB queries on spam.

## Test plan
- [ ] `/set_min_msg_length 5`; send "hi" → no score. Send "hello world" → score.
- [ ] `/set_msg_cooldown 10`; send two messages back-to-back; confirm only the first scored.
- [ ] Set both to 0; confirm scoring is unrestricted again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)