### PR TITLE
feat(audit): audit log channel for admin commands

### DIFF
--- a/.sqlx/query-64cea2a85587805beaaee56033b563e69d1efd1a20e8220f015b3c8e307ee0ff.json
+++ b/.sqlx/query-64cea2a85587805beaaee56033b563e69d1efd1a20e8220f015b3c8e307ee0ff.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO guilds (id, prefix, welcome_msg, voice_multiplier, text_multiplier, audit_log_channel_id) VALUES ($1, '!', '', 1, 1, $2) ON CONFLICT (id) DO UPDATE SET audit_log_channel_id = EXCLUDED.audit_log_channel_id",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "64cea2a85587805beaaee56033b563e69d1efd1a20e8220f015b3c8e307ee0ff"
+}

--- a/.sqlx/query-de3512d9fe24f1a73bc0757b18feb8be535ca3270573c50b1c1253d08e8a4bbc.json
+++ b/.sqlx/query-de3512d9fe24f1a73bc0757b18feb8be535ca3270573c50b1c1253d08e8a4bbc.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT audit_log_channel_id FROM guilds WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "audit_log_channel_id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "de3512d9fe24f1a73bc0757b18feb8be535ca3270573c50b1c1253d08e8a4bbc"
+}

--- a/migrations/20260629000008_audit_log.sql
+++ b/migrations/20260629000008_audit_log.sql
@@ -1,0 +1,2 @@
+ALTER TABLE guilds
+    ADD COLUMN audit_log_channel_id BIGINT;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod leaderboard;
 pub mod multipliers;
 pub mod reset_scores;
 pub mod role_thresholds;
+pub mod set_audit_channel;
 pub mod set_decay_rate;
 pub mod set_prefix;
 pub mod set_text_multiplier;

--- a/src/commands/set_audit_channel.rs
+++ b/src/commands/set_audit_channel.rs
@@ -1,0 +1,31 @@
+use serenity::all::Channel;
+
+use crate::{db::guilds::GuildRepo, Context, Error};
+
+/// Send a log line to this channel whenever an admin command runs. Omit the
+/// channel to disable.
+#[poise::command(
+    prefix_command,
+    slash_command,
+    required_permissions = "ADMINISTRATOR",
+    guild_only
+)]
+pub async fn set_audit_channel(
+    ctx: Context<'_>,
+    #[description = "Channel to log to (omit to disable)"] channel: Option<Channel>,
+) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let channel_id = channel.as_ref().map(|c| c.id().get() as i64);
+    let reply = match ctx.data().guilds.set_audit_channel(guild_id, channel_id).await {
+        Ok(()) => match channel_id {
+            Some(id) => format!("audit log channel set to <#{}>", id),
+            None => "audit logging disabled".to_string(),
+        },
+        Err(e) => {
+            eprintln!("[set_audit_channel] db error: {e}");
+            "failed to set audit channel".to_string()
+        }
+    };
+    ctx.say(reply).await?;
+    Ok(())
+}

--- a/src/db/guilds.rs
+++ b/src/db/guilds.rs
@@ -55,6 +55,8 @@ pub trait GuildRepo {
     async fn set_min_msg_length(&self, guild_id: i64, len: i32) -> Result<(), Error>;
     async fn set_msg_cooldown(&self, guild_id: i64, secs: i32) -> Result<(), Error>;
     async fn get_anti_spam(&self, guild_id: i64) -> AntiSpamSettings;
+    async fn set_audit_channel(&self, guild_id: i64, channel_id: Option<i64>) -> Result<(), Error>;
+    async fn get_audit_channel(&self, guild_id: i64) -> Option<i64>;
     async fn guilds(&self) -> Result<Vec<Guild>, Error>;
 }
 
@@ -222,6 +224,35 @@ impl GuildRepo for Guilds {
             },
             _ => AntiSpamSettings::default(),
         }
+    }
+
+    async fn set_audit_channel(
+        &self,
+        guild_id: i64,
+        channel_id: Option<i64>,
+    ) -> Result<(), Error> {
+        sqlx::query!(
+            "INSERT INTO guilds (id, prefix, welcome_msg, voice_multiplier, text_multiplier, audit_log_channel_id) \
+             VALUES ($1, '!', '', 1, 1, $2) \
+             ON CONFLICT (id) DO UPDATE SET audit_log_channel_id = EXCLUDED.audit_log_channel_id",
+            guild_id,
+            channel_id,
+        )
+        .execute(&self.pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn get_audit_channel(&self, guild_id: i64) -> Option<i64> {
+        sqlx::query_scalar!(
+            "SELECT audit_log_channel_id FROM guilds WHERE id = $1",
+            guild_id,
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+        .flatten()
     }
 
     async fn guilds(&self) -> Result<Vec<Guild>, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,9 @@ async fn main() {
                 commands::excluded_channels::excluded_channels(),
                 commands::anti_spam::set_min_msg_length(),
                 commands::anti_spam::set_msg_cooldown(),
+                commands::set_audit_channel::set_audit_channel(),
             ],
+            post_command: |ctx| Box::pin(services::audit::log_command(ctx)),
             prefix_options: poise::PrefixFrameworkOptions {
                 dynamic_prefix: Some(|ctx| {
                     Box::pin(async move {

--- a/src/services/audit.rs
+++ b/src/services/audit.rs
@@ -1,0 +1,29 @@
+use serenity::all::ChannelId;
+
+use crate::{db::guilds::GuildRepo, Context};
+
+/// Post a one-line audit log entry for the given command invocation, if the
+/// guild has configured an audit channel and the command requires
+/// ADMINISTRATOR. Silent no-op otherwise.
+pub async fn log_command(ctx: Context<'_>) {
+    let Some(guild_id) = ctx.guild_id() else {
+        return;
+    };
+    let cmd = ctx.command();
+    let requires_admin = cmd
+        .required_permissions
+        .contains(serenity::all::Permissions::ADMINISTRATOR);
+    if !requires_admin {
+        return;
+    }
+    let Some(channel_id) = ctx.data().guilds.get_audit_channel(guild_id.get() as i64).await
+    else {
+        return;
+    };
+    let invoked_with = ctx.invocation_string();
+    let msg = format!("[audit] {} ran `{}`", ctx.author().tag(), invoked_with);
+    let channel = ChannelId::new(channel_id as u64);
+    if let Err(e) = channel.say(ctx.http(), msg).await {
+        eprintln!("[audit] failed to write audit log: {e}");
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit;
 pub mod decay;
 pub mod message;
 pub mod roles;


### PR DESCRIPTION
**Stacks on top of #48.**

## Summary
- New `audit_log_channel_id` column on `guilds`.
- `services::audit::log_command` is registered as the poise `post_command` hook. It checks if the command requires ADMINISTRATOR and, if so, posts a one-liner to the configured channel.
- New `/set_audit_channel [#channel]` command — omit the channel to disable.

## Test plan
- [ ] `/set_audit_channel #bot-log`.
- [ ] Run any admin command (e.g. `/reset_scores`) → confirm the line shows up in #bot-log.
- [ ] Run a non-admin command (`/leaderboard`) → confirm no audit line.
- [ ] `/set_audit_channel` (no arg) → confirm audit logging stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)