### PR TITLE
feat(welcome): support {user}, {server}, {member_count} placeholders

### DIFF
--- a/assets/help.md
+++ b/assets/help.md
@@ -12,7 +12,7 @@ All commands are available as **slash commands** (`/leaderboard`, `/help`, …) 
 - `!download_leaderboard`: get a file .xlsx containing a table with all the users and related scores
 - `!set_prefix [PREFIX]`: Set the prefix for the Discord server in which the bot is running; (After this command the default `!` prefix will not be active, replaced by the one you set)
 - `!get_prefix [PREFIX]`: Get the prefix for the Discord server in which the bot is running, (This command will be always available also with the default prefix `!`)
-- `!set_welcome_msg [STRING]`: Set the welcome message
+- `!set_welcome_msg [STRING]`: Set the welcome message. Supports placeholders `{user}` (mention), `{username}` (display name), `{server}` (guild name), `{member_count}`. If the template contains none of these, the user mention is appended automatically (legacy behavior).
 - `!reset_scores`: Reset leaderboard scores
 - `!set_voice_multiplier [INTEGER]`: set the multiplier to calculate the points for the voice activity for a user in a Discord server. greater the multiplier, greater will be the wait to add a point to that user. For example, if the admin sets the multiplier to 5, the bot will wait 5 seconds before incrementing 1 point to the user
 - `!set_text_multiplier [INTEGER]`: set the multiplier for each message, this is simply the points for each message

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,7 @@ async fn event_handler(
                 .await
                 .filter(|s| !s.is_empty());
             let welcome_message = match template {
-                Some(m) => format!("{}, <@{}>!", m, new_member.user.id),
+                Some(m) => crate::services::welcome::render(ctx, &m, new_member).await,
                 None => format!("Welcome, <@{}>!", new_member.user.id),
             };
             if let Err(e) = channel_id.say(&ctx.http, welcome_message).await {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,3 +2,4 @@ pub mod audit;
 pub mod decay;
 pub mod message;
 pub mod roles;
+pub mod welcome;

--- a/src/services/welcome.rs
+++ b/src/services/welcome.rs
@@ -1,0 +1,36 @@
+use serenity::all::{Context, Member};
+
+/// Substitute supported placeholders in a welcome template. Supported tokens:
+///   {user}          — mention of the new member
+///   {username}      — plain display name (no mention)
+///   {server}        — guild name
+///   {member_count}  — current member count (best-effort from the cache)
+///
+/// Backwards compatibility: if the template contains none of the tokens
+/// above, the legacy "<msg>, <@user>!" form is produced so existing
+/// configurations keep working unchanged.
+pub async fn render(ctx: &Context, template: &str, member: &Member) -> String {
+    let has_token = template.contains("{user}")
+        || template.contains("{username}")
+        || template.contains("{server}")
+        || template.contains("{member_count}");
+    if !has_token {
+        return format!("{}, <@{}>!", template, member.user.id);
+    }
+
+    let user_mention = format!("<@{}>", member.user.id);
+    let username = member
+        .nick
+        .clone()
+        .unwrap_or_else(|| member.display_name().to_string());
+    let (server_name, member_count) = match ctx.cache.guild(member.guild_id) {
+        Some(g) => (g.name.clone(), g.member_count),
+        None => (String::new(), 0),
+    };
+
+    template
+        .replace("{user}", &user_mention)
+        .replace("{username}", &username)
+        .replace("{server}", &server_name)
+        .replace("{member_count}", &member_count.to_string())
+}


### PR DESCRIPTION
**Stacks on top of #49.**

## Summary
- New `services::welcome::render` substitutes `{user}`, `{username}`, `{server}`, `{member_count}` in the configured welcome template.
- Backwards compatible: if the template contains none of these tokens, the legacy `"<msg>, <@user>!"` formatting is used. Existing servers see no change.
- Help text updated.

## Test plan
- [ ] Set `/set_welcome_msg "Welcome {user} to {server} — you make us {member_count} strong"`. Have someone join. Confirm all three substitutions render.
- [ ] Set a plain string with no tokens (`/set_welcome_msg "Hi there"`) and confirm the mention is still appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)