### PR TITLE
feat(rank): /rank ephemeral self-rank check

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod get_prefix;
 pub mod help;
 pub mod leaderboard;
 pub mod multipliers;
+pub mod rank;
 pub mod reset_scores;
 pub mod role_thresholds;
 pub mod set_audit_channel;

--- a/src/commands/rank.rs
+++ b/src/commands/rank.rs
@@ -1,0 +1,20 @@
+use poise::CreateReply;
+
+use crate::{db::users::UsersRepo, Context, Error};
+
+/// Quick self-check: your current rank and score, replied ephemerally.
+#[poise::command(prefix_command, slash_command, guild_only)]
+pub async fn rank(ctx: Context<'_>) -> Result<(), Error> {
+    let guild_id = ctx.guild_id().unwrap().get() as i64;
+    let user_id = ctx.author().id.get() as i64;
+    let body = match ctx.data().users.get_user_stats(user_id, guild_id).await {
+        Ok(Some(s)) => format!("you are rank #{} with {} points", s.rank, s.score),
+        Ok(None) => "you have no activity recorded yet.".to_string(),
+        Err(e) => {
+            eprintln!("[rank] db error: {e}");
+            "failed to read rank".to_string()
+        }
+    };
+    ctx.send(CreateReply::default().content(body).ephemeral(true)).await?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ async fn main() {
                 commands::anti_spam::set_min_msg_length(),
                 commands::anti_spam::set_msg_cooldown(),
                 commands::set_audit_channel::set_audit_channel(),
+                commands::rank::rank(),
             ],
             post_command: |ctx| Box::pin(services::audit::log_command(ctx)),
             prefix_options: poise::PrefixFrameworkOptions {


### PR DESCRIPTION
**Stacks on top of #50.**

## Summary
- New `/rank` command. Reuses `get_user_stats`; sends an ephemeral reply with rank and score so users can check themselves in public channels without spamming.

## Test plan
- [ ] `/rank` in a public channel → confirm only you see the reply.
- [ ] Confirm the rank value matches your row on `/leaderboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)